### PR TITLE
Make BOM signature strings byte strings

### DIFF
--- a/chardet/universaldetector.py
+++ b/chardet/universaldetector.py
@@ -72,9 +72,9 @@ class UniversalDetector:
             # 00 00 FE FF  UTF-32, big-endian BOM
             ('\x00\x00\xFE\xFF', {'encoding': "UTF-32BE", 'confidence': 1.0}),
             # FE FF 00 00  UCS-4, unusual octet order BOM (3412)
-            (u'\xFE\xFF\x00\x00', {'encoding': "X-ISO-10646-UCS-4-3412", 'confidence': 1.0}),
+            ('\xFE\xFF\x00\x00', {'encoding': "X-ISO-10646-UCS-4-3412", 'confidence': 1.0}),
             # 00 00 FF FE  UCS-4, unusual octet order BOM (2143)
-            (u'\x00\x00\xFF\xFE', {'encoding': "X-ISO-10646-UCS-4-2143", 'confidence': 1.0}),
+            ('\x00\x00\xFF\xFE', {'encoding': "X-ISO-10646-UCS-4-2143", 'confidence': 1.0}),
             # FF FE  UTF-16, little endian BOM
             ('\xFF\xFE', {'encoding': "UTF-16LE", 'confidence': 1.0}),
             # FE FF  UTF-16, big endian BOM


### PR DESCRIPTION
... for X-ISO-10646-UCS-4-2143 and X...-ISO-10646-UCS-4-3412.

Testing my library that uses chardet on python-2.4 with chardet-1.1 I get this traceback:
# 
## ERROR: test_guess_encoding_with_chardet_installed (test_text_misc.TestTextMisc)

Traceback (most recent call last):
  File "/home/fedora/toshio/kitchen/kitchen-1.1.2a1/tests/test_text_misc.py", line 43, in test_guess_encoding_with_chardet_installed
    misc.guess_encoding(self.euc_jp_japanese)) == self.u_japanese)
  File "/home/fedora/toshio/kitchen/kitchen-1.1.2a1/kitchen/text/misc.py", line 91, in guess_encoding
    detection_info = chardet.detect(byte_string)
  File "/home/fedora/toshio/kitchen/lib/python2.4/site-packages/chardet/**init**.py", line 24, in detect
    u.feed(aBuf)
  File "/home/fedora/toshio/kitchen/lib/python2.4/site-packages/chardet/universaldetector.py", line 90, in feed
    if aBuf[:len(chunk)] == chunk:
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc2 in position 0: ordinal not in range(128)

This pull request fixes that by changing  the BOM signature strings for two UCS-4 signatures into byte strings (str) instead of unicode.
