### PR TITLE
Update version to be higher than Mark Pilgrim's last release

### DIFF
--- a/chardet/__init__.py
+++ b/chardet/__init__.py
@@ -15,7 +15,7 @@
 # 02110-1301  USA
 ######################### END LICENSE BLOCK #########################
 
-__version__ = "1.1"
+__version__ = "2.1.1"
 
 def detect(aBuf):
     import universaldetector

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ if not hasattr(DistributionMetadata, 'download_url'):
 
 setup(
     name = 'chardet',
-    version = '1.1',
+    version = '2.1.1',
     description = 'Universal encoding detector',
     long_description = """\
 Universal character encoding detector


### PR DESCRIPTION
Mark Pilgrim's last chardet release was version 2.0.1.  It's confusing to find a chardet that has an older version number that's actually a newer release.  Especially now that Mark's chardet upstream has  gone away.

Additionally, many Linux distributions have packaged the 2.0.1 version of chardet.  The package managers there are optimized for version numbers that increase.  They can be told to use a lower version number but it is confusing for end users of those packages (and sometimes, for unaware package maintainers that depend on the chardet package).

Unless there's a good reason, it would be nice to use a chardet version that is higher than 2.0.1.
