### PR TITLE
Return GB18030 for Simplified Chinese files.

### DIFF
--- a/chardet/gb2312prober.py
+++ b/chardet/gb2312prober.py
@@ -38,4 +38,4 @@ class GB2312Prober(MultiByteCharSetProber):
         self.reset()
 
     def get_charset_name(self):
-        return "GB2312"
+        return "GB18030"


### PR DESCRIPTION
GB2312 is a subset of GB18030 and covers fewer Chinese characters, which frequently leads to `UnicodeDecodeError`. Changing to GB18030 can fix the problem.
