### PR TITLE
Ensure that stdin is opened with mode 'rb'

### DIFF
--- a/chardet/chardetect.py
+++ b/chardet/chardetect.py
@@ -62,7 +62,7 @@ def main(argv=None):
     parser.add_argument('input',
                         help='File whose encoding we would like to determine.',
                         type=argparse.FileType('rb'), nargs='*',
-                        default=[sys.stdin])
+                        default=[open(sys.stdin.fileno(), 'rb')])
     parser.add_argument('--version', action='version',
                         version='%(prog)s {0}'.format(__version__))
     args = parser.parse_args(argv)


### PR DESCRIPTION
This fixes the following error:

```
$ echo foo bar | chardetect
Traceback (most recent call last):
...
TypeError: can't use a bytes pattern on a string-like object
```
