### PR TITLE
Display link to documentation in README.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,6 +26,10 @@ Install from `PyPI <https://pypi.python.org/pypi/chardet>`_::
 
     pip install chardet
 
+Documentation
+-------------
+
+For users, docs are now available at http://chardet.readthedocs.org.
 
 Command-line Tool
 -----------------


### PR DESCRIPTION
When I first started looking into this package I initially found it difficult to find the user oriented documentation. Right now, a link to the docs are not displayed on the github page, nor the PyPI page. This will hopefully make it simpler for other users.