### PR TITLE
Fix chardet.detect exception

### DIFF
--- a/chardet/__init__.py
+++ b/chardet/__init__.py
@@ -16,16 +16,15 @@
 ######################### END LICENSE BLOCK #########################
 
 
-from .compat import PY2, PY3
+from .compat import PY2, PY3, bin_type as _bin_type
 from .universaldetector import UniversalDetector
 from .version import __version__, VERSION
 
 
 def detect(byte_str):
-    if (PY2 and isinstance(byte_str, unicode)) or (PY3 and
-                                               not isinstance(byte_str,
-                                                              bytes)):
-        raise ValueError('Expected a bytes object, not a unicode object')
+    if not isinstance(byte_str, _bin_type):
+        raise TypeError('Expected object of {0} type, got: {1}'
+                        ''.format(_bin_type, type(byte_str)))
 
     u = UniversalDetector()
     u.feed(byte_str)

--- a/chardet/compat.py
+++ b/chardet/compat.py
@@ -27,11 +27,13 @@ if sys.version_info < (3, 0):
     PY3 = False
     base_str = (str, unicode)
     text_type = unicode
+    bin_type = str
 else:
     PY2 = False
     PY3 = True
     base_str = (bytes, str)
     text_type = str
+    bin_type = (bytes, bytearray)
 
 
 def wrap_ord(a):


### PR DESCRIPTION
First, it is wrong: ValueError is about bad value of the right type,
but the error and the check is about type, not value.

Second, it lies about argument type assuming it unicode for all the
cases that are not valid. What gives you happy debug times until you
finally open chardet source code.

Third, chardet need to respect bytearray type as it could work with it
fine and which one is a legit for holding binary strings in PY3.