### PR TITLE
Add Hypothesis based test of chardet

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,14 @@ python:
   - 3.4
   - pypy
 
+cache:
+    directories:
+        - $HOME/.hypothesis
+
+env:
+  global:
+    - HYPOTHESIS_STORAGE_DIRECTORY=$HOME/.hypothesis
+
 install:
   - travis_retry pip install python-coveralls nose-cov hypothesis
   - pip install .

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ python:
   - pypy
 
 install:
-  - travis_retry pip install python-coveralls nose-cov
+  - travis_retry pip install python-coveralls nose-cov hypothesis
   - pip install .
 
 # Run test

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,6 @@ setup(name='chardet',
                    "Topic :: Text Processing :: Linguistic"],
       packages=find_packages(),
       install_requires=['enum34'] if sys.version_info < (3, 4) else [],
-      test_requires=['nose'],
+      test_requires=['nose', 'hypothesis'],
       entry_points={'console_scripts':
                     ['chardetect = chardet.cli.chardetect:main']})

--- a/test.py
+++ b/test.py
@@ -7,12 +7,12 @@ Run chardet on a bunch of documents and see that we get the correct encodings.
 
 from __future__ import with_statement
 
-from hypothesis import given, assume
+from hypothesis import given, assume, Settings, Verbosity
 import hypothesis.strategies as st
 from os import listdir
 from os.path import dirname, isdir, join, realpath, relpath, splitext
 
-from nose.tools import eq_
+from nose.tools import eq_, assert_raises
 
 import chardet
 
@@ -60,13 +60,30 @@ def test_encoding_detection():
             yield check_file_encoding, join(path, file_name), encoding
 
 
-@given(st.text(min_size=100), st.sampled_from([
-       'ascii', 'utf-8', 'utf-16', 'utf-32',
-       'iso-8859-7', 'iso-8859-8', 'windows-1255']))
-def test_never_fails_to_detect_if_there_is_a_valid_encoding(txt, enc):
+class JustALengthIssue(Exception):
+    pass
+
+
+@given(st.text(min_size=1), st.sampled_from([
+           'ascii', 'utf-8', 'utf-16', 'utf-32',
+           'iso-8859-7', 'iso-8859-8', 'windows-1255']),
+       st.randoms(), settings=Settings(max_examples=200))
+def test_never_fails_to_detect_if_there_is_a_valid_encoding(txt, enc, rnd):
     try:
         data = txt.encode(enc)
     except UnicodeEncodeError:
         assume(False)
     detected = chardet.detect(data)['encoding']
-    assert detected is not None
+    if detected is None:
+        @given(st.text(), settings=Settings(
+            verbosity=Verbosity.quiet, max_shrinks=0,
+            max_examples=50,
+        ), random=rnd)
+        def string_poisons_following_text(suffix):
+            try:
+                extended = (txt + suffix).encode(enc)
+            except UnicodeEncodeError:
+                assume(False)
+            if chardet.detect(extended)['encoding'] is not None:
+                raise JustALengthIssue()
+        assert_raises(JustALengthIssue, string_poisons_following_text)


### PR DESCRIPTION
The concept here is pretty simple: This tries to test for the
invariant that if a string comes from valid unicode and is
encoded in one of the chardet supported encodings then chardet
should detect *some* encoding.

More nuanced tests are possible (e.g. asserting that the string
should be decodable from the detected encoding) but given
that even this test is demonstrating a bunch of bugs this seemed to
be a good starting point.

This is (more or less) the test that caught #65, #64 and #63. #62 had one extra line in it to try to reencode the data as the reported format. 

Notes:

  1. This test is currently failing. I'm pretty sure this is because of issues it's finding in the code, not issues with the test.
  2. min_size=100 is to rule out bugs that come solely from the length, prompted by your saying that short strings aren't really supported. Anecdotally all of the bugs that have been found so far don't depend on the length and min_size=1 would have been fine (leaving min_size alone is also valid, but I assume '' having a None encoding is intended behaviour)