### PR TITLE
Added tox script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ PKG-INFO
 /dist
 /build
 .hypothesis
+.coverage
+.tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
   - 2.7
   - 3.3
   - 3.4
+  - 3.5
   - pypy
 
 cache:
@@ -16,17 +17,11 @@ env:
     - HYPOTHESIS_STORAGE_DIRECTORY=$HOME/.hypothesis
 
 install:
-  - travis_retry pip install python-coveralls nose-cov hypothesis
-  - pip install .
+  - pip install tox
 
 # Run test
 script:
-  - if [[ $TRAVIS_PYTHON_VERSION != 'pypy' ]]; then nosetests -v --with-cov --cov chardet --cov-config .coveragerc --logging-level=DEBUG; fi
-  - if [[ $TRAVIS_PYTHON_VERSION == 'pypy' ]]; then nosetests -v --logging-level=DEBUG; fi
-
-# Calculate coverage
-after_success:
-  - if [[ $TRAVIS_PYTHON_VERSION != 'pypy' ]]; then coveralls --config_file .coveragerc; fi
+  - tox -e $(echo $TRAVIS_PYTHON_VERSION | sed 's/^\([0-9]\)\.\([0-9]\).*/py\1\2/')
 
 notifications:
   email:

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,16 @@
+[tox]
+envlist = py26, py27, py33, py34, py35, pypy
+
+[testenv]
+passenv = HYPOTHESIS_STORAGE_DIRECTORY
+
+deps =
+  nose-cov
+  hypothesis
+
+commands =
+  nosetests -v --logging-level=DEBUG --with-cov --cov chardet --cov-config .coveragerc
+  coveralls --config_file .coveragerc
+
+[testenv:pypy]
+commands = nosetests -v --logging-level=DEBUG


### PR DESCRIPTION
This PR adds a tox script in order to make running tests easy. So you can simply run `tox` and it will setup virtual environments for each supported Python version, installing test requirements, and running the tests.
