### PR TITLE
Note that ISO-8859-1 is equivalent (for chardet) to Windows 1252

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,7 @@ Detects
  - EUC-KR, ISO-2022-KR (Korean)
  - KOI8-R, MacCyrillic, IBM855, IBM866, ISO-8859-5, windows-1251 (Cyrillic)
  - ISO-8859-5, windows-1251 (Bulgarian)
- - windows-1252 (English)
+ - ISO-8859-1, windows-1252 (Western European languages)
  - ISO-8859-7, windows-1253 (Greek)
  - ISO-8859-8, windows-1255 (Visual and Logical Hebrew)
  - TIS-620 (Thai)

--- a/docs/how-it-works.rst
+++ b/docs/how-it-works.rst
@@ -30,9 +30,10 @@ There are 5 categories of encodings that ``UniversalDetector`` handles:
 #. Single-byte encodings, where each character is represented by one
    byte. Examples: ``KOI8-R`` (Russian), ``windows-1255`` (Hebrew), and
    ``TIS-620`` (Thai).
-#. ``windows-1252``, which is used primarily on Microsoft Windows by
-   middle managers who don’t know a character encoding from a hole in
-   the ground.
+#. ``windows-1252``, which is used primarily on Microsoft Windows; its
+   subset, ``ISO-8859-1`` is widely used for legacy 8-bit-encoded text.
+   chardet, like many encoding detectors, defaults to guessing this
+   encoding when no other can be reliably established.
 
 ``UTF-n`` with a BOM
 --------------------

--- a/docs/supported-encodings.rst
+++ b/docs/supported-encodings.rst
@@ -12,7 +12,7 @@ encodings.
    and ``windows-1251`` (Russian)
 -  ``ISO-8859-2`` and ``windows-1250`` (Hungarian)
 -  ``ISO-8859-5`` and ``windows-1251`` (Bulgarian)
--  ``windows-1252``
+-  ``ISO-8859-1`` and ``windows-1252`` (Western European languages)
 -  ``ISO-8859-7`` and ``windows-1253`` (Greek)
 -  ``ISO-8859-8`` and ``windows-1255`` (Visual and Logical Hebrew)
 -  ``TIS-620`` (Thai)


### PR DESCRIPTION
I also changed a derogatory reference to middle managers to a more
useful explanation Windows 1252/ISO-8859-1.