### PR TITLE
treat spaces as single-char bytes instead of strings for python 2/3

### DIFF
--- a/chardet/compat.py
+++ b/chardet/compat.py
@@ -36,8 +36,11 @@ else:
     bin_type = (bytes, bytearray)
 
 
-def wrap_ord(a):
-    if PY2 and isinstance(a, base_str):
-        return ord(a)
-    else:
-        return a
+if PY2:
+    def wrap_ord(a):
+        if isinstance(a, base_str):
+            return ord(a)
+        else:
+            return a
+else:
+    wrap_ord = int  # leaves the input unchanged

--- a/chardet/hebrewprober.py
+++ b/chardet/hebrewprober.py
@@ -138,6 +138,7 @@ class HebrewProber(CharSetProber):
     NORMAL_PE = 0xf4
     FINAL_TSADI = 0xf5
     NORMAL_TSADI = 0xf6
+    SPACE = 0x20
 
     # Minimum Visual vs Logical final letter score difference.
     # If the difference is below this, don't rely solely on the final letter score
@@ -168,8 +169,8 @@ class HebrewProber(CharSetProber):
         # The two last characters seen in the previous buffer,
         # mPrev and mBeforePrev are initialized to space in order to simulate
         # a word delimiter at the beginning of the data
-        self._prev = ' '
-        self._before_prev = ' '
+        self._prev = self.SPACE
+        self._before_prev = self.SPACE
         # These probers are owned by the group prober.
 
     def set_model_probers(self, logicalProber, visualProber):
@@ -228,9 +229,9 @@ class HebrewProber(CharSetProber):
         byte_str = self.filter_high_byte_only(byte_str)
 
         for cur in byte_str:
-            if cur == ' ':
+            if cur == self.SPACE:
                 # We stand on a space - a word just ended
-                if self._before_prev != ' ':
+                if self._before_prev != self.SPACE:
                     # next-to-last char was not a space so self._prev is not a
                     # 1 letter word
                     if self.is_final(self._prev):
@@ -242,8 +243,8 @@ class HebrewProber(CharSetProber):
                         self._final_char_visual_score += 1
             else:
                 # Not standing on a space
-                if ((self._before_prev == ' ') and
-                        (self.is_final(self._prev)) and (cur != ' ')):
+                if ((self._before_prev == self.SPACE) and
+                        (self.is_final(self._prev)) and (cur != self.SPACE)):
                     # case (3) [-2:space][-1:final letter][cur:not space]
                     self._final_char_visual_score += 1
             self._before_prev = self._prev

--- a/chardet/hebrewprober.py
+++ b/chardet/hebrewprober.py
@@ -126,6 +126,8 @@ from .compat import wrap_ord
 # model probers scores. The answer is returned in the form of the name of the
 # charset identified, either "windows-1255" or "ISO-8859-8".
 
+SPACE_BYTE = b' '[0]  # does the right thing PY2/PY3
+
 class HebrewProber(CharSetProber):
     # windows-1255 / ISO-8859-8 code points of interest
     FINAL_KAF = 0xea
@@ -138,7 +140,6 @@ class HebrewProber(CharSetProber):
     NORMAL_PE = 0xf4
     FINAL_TSADI = 0xf5
     NORMAL_TSADI = 0xf6
-    SPACE = 0x20
 
     # Minimum Visual vs Logical final letter score difference.
     # If the difference is below this, don't rely solely on the final letter score
@@ -169,8 +170,8 @@ class HebrewProber(CharSetProber):
         # The two last characters seen in the previous buffer,
         # mPrev and mBeforePrev are initialized to space in order to simulate
         # a word delimiter at the beginning of the data
-        self._prev = self.SPACE
-        self._before_prev = self.SPACE
+        self._prev = SPACE_BYTE
+        self._before_prev = SPACE_BYTE
         # These probers are owned by the group prober.
 
     def set_model_probers(self, logicalProber, visualProber):
@@ -229,9 +230,9 @@ class HebrewProber(CharSetProber):
         byte_str = self.filter_high_byte_only(byte_str)
 
         for cur in byte_str:
-            if cur == self.SPACE:
+            if cur == SPACE_BYTE:
                 # We stand on a space - a word just ended
-                if self._before_prev != self.SPACE:
+                if self._before_prev != SPACE_BYTE:
                     # next-to-last char was not a space so self._prev is not a
                     # 1 letter word
                     if self.is_final(self._prev):
@@ -243,8 +244,8 @@ class HebrewProber(CharSetProber):
                         self._final_char_visual_score += 1
             else:
                 # Not standing on a space
-                if ((self._before_prev == self.SPACE) and
-                        (self.is_final(self._prev)) and (cur != self.SPACE)):
+                if ((self._before_prev == SPACE_BYTE) and
+                        (self.is_final(self._prev)) and (cur != SPACE_BYTE)):
                     # case (3) [-2:space][-1:final letter][cur:not space]
                     self._final_char_visual_score += 1
             self._before_prev = self._prev


### PR DESCRIPTION
The initial state of self._prev is pretty suspect currently. python2 will gladly compare a string to an int (coming from wrap_ord()) and quietly return False. Likewise it will do tests for one char of a bytestring like:
  b'x' in [ord(b'x')]  # unexpectedly False

This patch fixes handling of the initial condition and comparing spaces but not the other issue of the class level character constants.
