### PR TITLE
Report back Windows encodings only when we have evidence

### DIFF
--- a/chardet/latin1prober.py
+++ b/chardet/latin1prober.py
@@ -108,7 +108,7 @@ class Latin1Prober(CharSetProber):
 
     @property
     def charset_name(self):
-        return "windows-1252"
+        return "ISO-8859-1"
 
     def feed(self, byte_str):
         byte_str = self.filter_with_english_letters(byte_str)


### PR DESCRIPTION
This fixes some mixups where we would report ISO encodings even when we saw bytes in the `\x80-\x9F` range.

This was pulled out of #99 to make that PR smaller.