### PR TITLE
stop reading file immediately when filetype known

### DIFF
--- a/chardet/cli/chardetect.py
+++ b/chardet/cli/chardetect.py
@@ -39,6 +39,9 @@ def description_of(lines, name='stdin'):
     u = UniversalDetector()
     for line in lines:
         u.feed(line)
+        # shortcut out of the loop to save reading further - particularly useful if we read a BOM.
+        if u.done:
+            break
     u.close()
     result = u.result
     if PY2:


### PR DESCRIPTION
This should be a useful performance improvement.   I've got some 100MB files and they take quite a few seconds to read through from my local SSD - and imagine if someone was reading across the network.

If the unicode byte-order mark is read in the first line of the file, it really makes no sense to read the rest of the file off disk.

I fixed the unit tests in the previous PR because I wanted to assure myself this introduced no regression (it appears not to.)

cheers