### PR TITLE
Add API option to get all the encodings confidence #96

### DIFF
--- a/chardet/__init__.py
+++ b/chardet/__init__.py
@@ -76,6 +76,7 @@ def detect_all(byte_str):
                     'encoding': charset_name,
                     'confidence': prober.get_confidence()
                 })
-        return sorted(results, key=lambda result: -result['confidence'])
-    
+        if len(results) > 0:
+            return sorted(results, key=lambda result: -result['confidence'])
+
     return [detector.result]

--- a/chardet/__init__.py
+++ b/chardet/__init__.py
@@ -21,12 +21,14 @@ from .universaldetector import UniversalDetector
 from .version import __version__, VERSION
 
 
-def detect(byte_str):
+def detect(byte_str, return_all=False):
     """
     Detect the encoding of the given byte string.
 
     :param byte_str:     The byte sequence to examine.
     :type byte_str:      ``bytes`` or ``bytearray``
+    :param return_all:   Whether to return all the results or only the best
+    :type return_all:    ``bool``
     """
     if not isinstance(byte_str, bytearray):
         if not isinstance(byte_str, bytes):
@@ -36,4 +38,5 @@ def detect(byte_str):
             byte_str = bytearray(byte_str)
     detector = UniversalDetector()
     detector.feed(byte_str)
-    return detector.close()
+    detector.close()
+    return detector.all_results if return_all else detector.result

--- a/chardet/__init__.py
+++ b/chardet/__init__.py
@@ -16,19 +16,20 @@
 ######################### END LICENSE BLOCK #########################
 
 
-from .compat import PY2, PY3
 from .universaldetector import UniversalDetector
+from .enums import InputState
 from .version import __version__, VERSION
 
 
-def detect(byte_str, return_all=False):
+__all__ = ['UniversalDetector', 'detect', 'detect_all', '__version__', 'VERSION']
+
+
+def detect(byte_str):
     """
     Detect the encoding of the given byte string.
 
     :param byte_str:     The byte sequence to examine.
     :type byte_str:      ``bytes`` or ``bytearray``
-    :param return_all:   Whether to return all the results or only the best
-    :type return_all:    ``bool``
     """
     if not isinstance(byte_str, bytearray):
         if not isinstance(byte_str, bytes):
@@ -38,5 +39,43 @@ def detect(byte_str, return_all=False):
             byte_str = bytearray(byte_str)
     detector = UniversalDetector()
     detector.feed(byte_str)
+    return detector.close()
+
+
+def detect_all(byte_str):
+    """
+    Detect all the possible encodings of the given byte string.
+
+    :param byte_str:     The byte sequence to examine.
+    :type byte_str:      ``bytes`` or ``bytearray``
+    """
+    if not isinstance(byte_str, bytearray):
+        if not isinstance(byte_str, bytes):
+            raise TypeError('Expected object of type bytes or bytearray, got: '
+                            '{0}'.format(type(byte_str)))
+        else:
+            byte_str = bytearray(byte_str)
+
+    detector = UniversalDetector()
+    detector.feed(byte_str)
     detector.close()
-    return detector.all_results if return_all else detector.result
+
+    if detector._input_state == InputState.HIGH_BYTE:
+        results = []
+        for prober in detector._charset_probers:
+            if prober.get_confidence() > detector.MINIMUM_THRESHOLD:
+                charset_name = prober.charset_name
+                lower_charset_name = prober.charset_name.lower()
+                # Use Windows encoding name instead of ISO-8859 if we saw any
+                # extra Windows-specific bytes
+                if lower_charset_name.startswith('iso-8859'):
+                    if detector._has_win_bytes:
+                        charset_name = detector.ISO_WIN_MAP.get(lower_charset_name,
+                                                            charset_name)
+                results.append({
+                    'encoding': charset_name,
+                    'confidence': prober.get_confidence()
+                })
+        return sorted(results, key=lambda result: -result['confidence'])
+    
+    return [detector.result]

--- a/chardet/universaldetector.py
+++ b/chardet/universaldetector.py
@@ -82,6 +82,7 @@ class UniversalDetector(object):
         self._esc_charset_prober = None
         self._charset_probers = []
         self.result = None
+        self.all_results = []
         self.done = None
         self._got_data = None
         self._input_state = None
@@ -98,6 +99,7 @@ class UniversalDetector(object):
         call this directly in between analyses of different documents.
         """
         self.result = {'encoding': None, 'confidence': 0.0, 'language': None}
+        self.all_results = [self.result]
         self.done = False
         self._got_data = False
         self._has_win_bytes = False
@@ -227,6 +229,7 @@ class UniversalDetector(object):
         """
         # Don't bother with checks if we're already done
         if self.done:
+            self.all_results = [self.result]
             return self.result
         self.done = True
 
@@ -238,32 +241,35 @@ class UniversalDetector(object):
             self.result = {'encoding': 'ascii',
                            'confidence': 1.0,
                            'language': ''}
+            self.all_results = [self.result]
+            return self.result
 
         # If we have seen non-ASCII, return the best that met MINIMUM_THRESHOLD
-        elif self._input_state == InputState.HIGH_BYTE:
-            prober_confidence = None
-            max_prober_confidence = 0.0
-            max_prober = None
+        if self._input_state == InputState.HIGH_BYTE:
+            results = []
             for prober in self._charset_probers:
                 if not prober:
                     continue
-                prober_confidence = prober.get_confidence()
-                if prober_confidence > max_prober_confidence:
-                    max_prober_confidence = prober_confidence
-                    max_prober = prober
-            if max_prober and (max_prober_confidence > self.MINIMUM_THRESHOLD):
-                charset_name = max_prober.charset_name
-                lower_charset_name = max_prober.charset_name.lower()
-                confidence = max_prober.get_confidence()
-                # Use Windows encoding name instead of ISO-8859 if we saw any
-                # extra Windows-specific bytes
-                if lower_charset_name.startswith('iso-8859'):
-                    if self._has_win_bytes:
-                        charset_name = self.ISO_WIN_MAP.get(lower_charset_name,
-                                                            charset_name)
-                self.result = {'encoding': charset_name,
-                               'confidence': confidence,
-                               'language': max_prober.language}
+                confidence = prober.get_confidence()
+                if confidence > self.MINIMUM_THRESHOLD:
+                    charset_name = prober.charset_name
+                    lower_charset_name = prober.charset_name.lower()
+                    # Use Windows encoding name instead of ISO-8859 if we saw any
+                    # extra Windows-specific bytes
+                    if lower_charset_name.startswith('iso-8859'):
+                        if self._has_win_bytes:
+                            charset_name = self.ISO_WIN_MAP.get(lower_charset_name,
+                                                                charset_name)
+                    results.append({
+                        'encoding': charset_name,
+                        'confidence': confidence,
+                        'language': prober.language,
+                    })
+            results = sorted(results, key=lambda r: -r['confidence'])
+            if len(results) > 0:
+                self.all_results = results
+                self.result = results[0]
+                return self.result
 
         # Log all prober confidences if none met MINIMUM_THRESHOLD
         if self.logger.getEffectiveLevel() == logging.DEBUG:

--- a/chardet/universaldetector.py
+++ b/chardet/universaldetector.py
@@ -167,6 +167,7 @@ class UniversalDetector(object):
 
             self._got_data = True
             if self.result['encoding'] is not None:
+                self.all_results = [self.result]
                 self.done = True
                 return
 
@@ -195,6 +196,7 @@ class UniversalDetector(object):
                                self._esc_charset_prober.get_confidence(),
                                'language':
                                self._esc_charset_prober.language}
+                self.all_results = [self.result]
                 self.done = True
         # If we've seen high bytes (i.e., those with values greater than 127),
         # we need to do more complicated checks using all our multi-byte and
@@ -214,6 +216,7 @@ class UniversalDetector(object):
                     self.result = {'encoding': prober.charset_name,
                                    'confidence': prober.get_confidence(),
                                    'language': prober.language}
+                    self.all_results = [self.result]
                     self.done = True
                     break
             if self.WIN_BYTE_DETECTOR.search(byte_str):
@@ -229,7 +232,6 @@ class UniversalDetector(object):
         """
         # Don't bother with checks if we're already done
         if self.done:
-            self.all_results = [self.result]
             return self.result
         self.done = True
 

--- a/test.py
+++ b/test.py
@@ -126,3 +126,20 @@ if HAVE_HYPOTHESIS:
                     result = chardet.detect(extended)
                     if result and result['encoding'] is not None:
                         raise JustALengthIssue()
+
+    @given(st.text(min_size=1), st.sampled_from(['ascii', 'utf-8', 'utf-16',
+                                                 'utf-32', 'iso-8859-7',
+                                                 'iso-8859-8', 'windows-1255']),
+           st.randoms())
+    @settings(max_examples=200)
+    def test_detect_all_and_detect_one_should_agree(txt, enc, rnd):
+        try:
+            data = txt.encode(enc)
+        except UnicodeEncodeError:
+            assume(False)
+        try:
+            result = chardet.detect(data)
+            results = chardet.detect(data, return_all=True)
+            assert result['encoding'] == results[0]['encoding']
+        except Exception:
+            raise Exception('%s != %s' % (result, results))

--- a/test.py
+++ b/test.py
@@ -127,6 +127,7 @@ if HAVE_HYPOTHESIS:
                     if result and result['encoding'] is not None:
                         raise JustALengthIssue()
 
+
     @given(st.text(min_size=1), st.sampled_from(['ascii', 'utf-8', 'utf-16',
                                                  'utf-32', 'iso-8859-7',
                                                  'iso-8859-8', 'windows-1255']),
@@ -139,7 +140,7 @@ if HAVE_HYPOTHESIS:
             assume(False)
         try:
             result = chardet.detect(data)
-            results = chardet.detect(data, return_all=True)
+            results = chardet.detect_all(data)
             assert result['encoding'] == results[0]['encoding']
         except Exception:
             raise Exception('%s != %s' % (result, results))


### PR DESCRIPTION
As discussed in #96, here's my solution for the encodings listing problem.

For info, this was my first  version: Just adding a method `detect_all` to `__init__.py`:

```python
def detect_all(byte_str):
    if not isinstance(byte_str, _bin_type):
        raise TypeError('Expected object of {0} type, got: {1}'
                        ''.format(_bin_type, type(byte_str)))

    u = UniversalDetector()
    u.feed(byte_str)
    u.close()

    results = [
        {
            'encoding': prober.charset_name,
            'confidence': prober.get_confidence()
        } for prober in u._charset_probers
            if prober.get_confidence() > u.MINIMUM_THRESHOLD
    ]
    return sorted(results, key=lambda r: -r['confidence'])
```