### PR TITLE
Prefer readthedocs.io over readthedocs.org

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -48,7 +48,7 @@ Install from `PyPI <https://pypi.python.org/pypi/chardet>`_::
 Documentation
 -------------
 
-For users, docs are now available at http://chardet.readthedocs.org.
+For users, docs are now available at https://chardet.readthedocs.io/.
 
 Command-line Tool
 -----------------

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,3 @@
-For users, docs are now available at http://chardet.readthedocs.org.
+For users, docs are now available at https://chardet.readthedocs.io/.
 
 For devs, you can edit the RST files in this directory.


### PR DESCRIPTION
Projects should now use readthedocs.io instead of readthedocs.org. Fixed links to use https.