### PR TITLE
Drop support for Python 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 language: python
 sudo: false
 python:
-  - 2.6
   - 2.7
-  - 3.3
   - 3.4
   - 3.5
   - 3.6
@@ -20,8 +18,6 @@ env:
 install:
   - travis_retry pip install --upgrade pip
   - travis_retry pip install --upgrade --upgrade-strategy only-if-needed pytest pytest-catchlog
-  # Hypothesis doesn't work on 2.6
-  - if [ $TRAVIS_PYTHON_VERSION != "2.6" ]; then travis_retry pip install hypothesis; fi
   - pip install .
 
 # Run test

--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,7 @@ Detects
    Our ISO-8859-2 and windows-1250 (Hungarian) probers have been temporarily
    disabled until we can retrain the models.
 
-Requires Python 2.6, 2.7, or 3.3+.
+Requires Python 2.7 or 3.4+.
 
 Installation
 ------------
@@ -63,6 +63,6 @@ This is a continuation of Mark Pilgrim's excellent chardet. Previously, two
 versions needed to be maintained: one that supported python 2.x and one that
 supported python 3.x.  We've recently merged with `Ian Cordasco <https://github.com/sigmavirus24>`_'s
 `charade <https://github.com/sigmavirus24/charade>`_ fork, so now we have one
-coherent version that works for Python 2.6+.
+coherent version that works for Python 2.7+ and 3.4+.
 
 :maintainer: Dan Blanchard

--- a/bench.py
+++ b/bench.py
@@ -26,12 +26,12 @@ except:
 
 # TODO: Restore Hungarian encodings (iso-8859-2 and windows-1250) after we
 #       retrain model.
-MISSING_ENCODINGS = set(['iso-8859-2', 'iso-8859-6', 'windows-1250',
-                         'windows-1254', 'windows-1256'])
-EXPECTED_FAILURES = set(['tests/iso-8859-7-greek/disabled.gr.xml',
-                         'tests/iso-8859-9-turkish/divxplanet.com.xml',
-                         'tests/iso-8859-9-turkish/subtitle.srt',
-                         'tests/iso-8859-9-turkish/wikitop_tr_ISO-8859-9.txt'])
+MISSING_ENCODINGS = {'iso-8859-2', 'iso-8859-6', 'windows-1250',
+                     'windows-1254', 'windows-1256'}
+EXPECTED_FAILURES = {'tests/iso-8859-7-greek/disabled.gr.xml',
+                     'tests/iso-8859-9-turkish/divxplanet.com.xml',
+                     'tests/iso-8859-9-turkish/subtitle.srt',
+                     'tests/iso-8859-9-turkish/wikitop_tr_ISO-8859-9.txt'}
 
 def get_py_impl():
     """Return what kind of Python this is"""

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import sys
 from setuptools import find_packages, setup
 
 
-needs_pytest = set(['pytest', 'test', 'ptr']).intersection(sys.argv)
+needs_pytest = {'pytest', 'test', 'ptr'}.intersection(sys.argv)
 pytest_runner = ['pytest-runner'] if needs_pytest else []
 
 
@@ -39,10 +39,8 @@ setup(name='chardet',
                    "Operating System :: OS Independent",
                    "Programming Language :: Python",
                    'Programming Language :: Python :: 2',
-                   'Programming Language :: Python :: 2.6',
                    'Programming Language :: Python :: 2.7',
                    'Programming Language :: Python :: 3',
-                   'Programming Language :: Python :: 3.3',
                    'Programming Language :: Python :: 3.4',
                    'Programming Language :: Python :: 3.5',
                    'Programming Language :: Python :: 3.6',

--- a/test.py
+++ b/test.py
@@ -26,12 +26,12 @@ import chardet
 
 # TODO: Restore Hungarian encodings (iso-8859-2 and windows-1250) after we
 #       retrain model.
-MISSING_ENCODINGS = set(['iso-8859-2', 'iso-8859-6', 'windows-1250',
-                         'windows-1254', 'windows-1256'])
-EXPECTED_FAILURES = set(['tests/iso-8859-7-greek/disabled.gr.xml',
-                         'tests/iso-8859-9-turkish/divxplanet.com.xml',
-                         'tests/iso-8859-9-turkish/subtitle.srt',
-                         'tests/iso-8859-9-turkish/wikitop_tr_ISO-8859-9.txt'])
+MISSING_ENCODINGS = {'iso-8859-2', 'iso-8859-6', 'windows-1250',
+                     'windows-1254', 'windows-1256'}
+EXPECTED_FAILURES = {'tests/iso-8859-7-greek/disabled.gr.xml',
+                     'tests/iso-8859-9-turkish/divxplanet.com.xml',
+                     'tests/iso-8859-9-turkish/subtitle.srt',
+                     'tests/iso-8859-9-turkish/wikitop_tr_ISO-8859-9.txt'}
 
 def gen_test_params():
     """Yields tuples of paths and encodings to use for test_encoding_detection"""


### PR DESCRIPTION
Python 2.6 and 3.3 is EOL and is no longer receiving bug fixes, including security fixes.
    
https://snarky.ca/stop-using-python-2-6/
http://www.curiousefficiency.org/posts/2015/04/stop-supporting-python26.html
    
Fixes #133
