### PR TITLE
only decode if filesystem encoding is defined

### DIFF
--- a/chardet/cli/chardetect.py
+++ b/chardet/cli/chardetect.py
@@ -43,7 +43,9 @@ def description_of(lines, name='stdin'):
     u.close()
     result = u.result
     if PY2:
-        name = name.decode(sys.getfilesystemencoding(), 'ignore')
+        fs_enc = sys.getfilesystemencoding()
+        if fs_enc is not None:
+            name = name.decode(fs_enc, 'ignore')
     if result['encoding']:
         return '{0}: {1} with confidence {2}'.format(name, result['encoding'],
                                                      result['confidence'])


### PR DESCRIPTION
Hi there,

I had an issue where pip would fail to install because on my QNX system `sys.getfilesystemencoding()` returned `None`. This is conformant (see [the documentation](https://docs.python.org/2/library/sys.html#sys.getfilesystemencoding)) and has been fixed in distlib already (see [this issue](https://bitbucket.org/pypa/distlib/issues/99/distlib-encoding-failure-on-python-27)).
I originally reported it [to pip](https://github.com/pypa/pip/pull/4972), however it was suggested to fix it here directly.

Happy to hear any suggestions.

Cheers, André