### PR TITLE
CI: Install Hypothesis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ env:
 install:
   - travis_retry pip install --upgrade pip
   - travis_retry pip install --upgrade --upgrade-strategy only-if-needed pytest pytest-catchlog
+  - travis_retry pip install hypothesis
   - pip install .
 
 # Run test


### PR DESCRIPTION
Python 2.6 was dropped in PR https://github.com/chardet/chardet/pull/143, and it looks like Hypothesis was accidentally removed when it should be kept for non-2.6:

```yml
  # Hypothesis doesn't work on 2.6	
  - if [ $TRAVIS_PYTHON_VERSION != "2.6" ]; then travis_retry pip install hypothesis; fi
```

https://github.com/chardet/chardet/pull/143/files#diff-354f30a63fb0907d4ad57269548329e3L23