### PR TITLE
Workaround for distutils bug in python 2.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-import re
+
 import sys
 
 from setuptools import find_packages, setup
@@ -11,6 +11,7 @@ pytest_runner = ['pytest-runner'] if needs_pytest else []
 
 # Get version without importing, which avoids dependency issues
 def get_version():
+    import re
     with open('chardet/version.py') as version_file:
         return re.search(r"""__version__\s+=\s+(['"])(?P<version>.+?)\1""",
                          version_file.read()).group('version')


### PR DESCRIPTION
There is a weird bug in python 2.7 that causes a NameError when trying to install this package using `run_setup` in distutils..
https://bugs.python.org/issue23426 seams related, but does not work in this case.

Here is the error it fixes..

```
In [1]: from distutils.core import run_setup

In [2]: run_setup('setup.py', ['bdist_egg'])
---------------------------------------------------------------------------
NameError                                 Traceback (most recent call last)
<ipython-input-2-cd35a16b7b8c> in <module>()
----> 1 run_setup('setup.py', ['bdist_egg'])

/usr/local/lib/python2.7/distutils/core.pyc in run_setup(script_name, script_args, stop_after)
    216             f = open(script_name)
    217             try:
--> 218                 exec f.read() in g, l
    219             finally:
    220                 f.close()

/tmp/pip-temp-RZje_i/chardet/setup.py in <module>()

/tmp/pip-temp-RZje_i/chardet/setup.py in get_version()

NameError: global name 're' is not defined
```