### PR TITLE
Improved Hypothesis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ env:
 install:
   - travis_retry pip install --upgrade pip
   - travis_retry pip install --upgrade --upgrade-strategy only-if-needed pytest pytest-catchlog
+  - travis_retry pip install hypothesis
   - pip install .
 
 # Run test

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,6 @@ setup(name='chardet',
       packages=find_packages(),
       python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
       setup_requires=pytest_runner,
-      tests_require=['pytest', 'hypothesis'],
+      tests_require=['pytest>=3.1', 'hypothesis>=3.66.0'],
       entry_points={'console_scripts':
                     ['chardetect = chardet.cli.chardetect:main']})

--- a/test.py
+++ b/test.py
@@ -13,13 +13,9 @@ from io import open
 from os import listdir
 from os.path import dirname, isdir, join, realpath, relpath, splitext
 
-try:
-    import hypothesis.strategies as st
-    from hypothesis import given, assume, settings, Verbosity
-    HAVE_HYPOTHESIS = True
-except ImportError:
-    HAVE_HYPOTHESIS = False
 import pytest
+import hypothesis.strategies as st
+from hypothesis import given, reject, settings, HealthCheck
 
 import chardet
 
@@ -97,50 +93,18 @@ def test_encoding_detection(file_name, encoding):
                                                    diff))
 
 
-if HAVE_HYPOTHESIS:
-    class JustALengthIssue(Exception):
-        pass
-
-
-    @pytest.mark.xfail
-    @given(st.text(min_size=1), st.sampled_from(['ascii', 'utf-8', 'utf-16',
-                                                 'utf-32', 'iso-8859-7',
-                                                 'iso-8859-8', 'windows-1255']),
-           st.randoms())
-    @settings(max_examples=200)
-    def test_never_fails_to_detect_if_there_is_a_valid_encoding(txt, enc, rnd):
-        try:
-            data = txt.encode(enc)
-        except UnicodeEncodeError:
-            assume(False)
-        detected = chardet.detect(data)['encoding']
-        if detected is None:
-            with pytest.raises(JustALengthIssue):
-                @given(st.text(), random=rnd)
-                @settings(verbosity=Verbosity.quiet, max_shrinks=0, max_examples=50)
-                def string_poisons_following_text(suffix):
-                    try:
-                        extended = (txt + suffix).encode(enc)
-                    except UnicodeEncodeError:
-                        assume(False)
-                    result = chardet.detect(extended)
-                    if result and result['encoding'] is not None:
-                        raise JustALengthIssue()
-
-
-    @given(st.text(min_size=1), st.sampled_from(['ascii', 'utf-8', 'utf-16',
-                                                 'utf-32', 'iso-8859-7',
-                                                 'iso-8859-8', 'windows-1255']),
-           st.randoms())
-    @settings(max_examples=200)
-    def test_detect_all_and_detect_one_should_agree(txt, enc, rnd):
-        try:
-            data = txt.encode(enc)
-        except UnicodeEncodeError:
-            assume(False)
-        try:
-            result = chardet.detect(data)
-            results = chardet.detect_all(data)
-            assert result['encoding'] == results[0]['encoding']
-        except Exception:
-            raise Exception('%s != %s' % (result, results))
+@pytest.mark.parametrize('enc', [
+    'ascii', 'utf-8', 'utf-16', 'utf-32',
+    'iso-8859-7', 'iso-8859-8', 'windows-1255',
+])
+@settings(suppress_health_check=[HealthCheck.filter_too_much])
+@given(txt=st.text(min_size=1))
+def test_detect_all_and_detect_one_always_agree(enc, txt):
+    try:
+        data = txt.encode(enc)
+    except UnicodeEncodeError:
+        reject()
+    result = chardet.detect(data)
+    results = chardet.detect_all(data)
+    assert result['encoding'] == results[0]['encoding'], \
+        '%s != %s[0]' % (result, results)

--- a/test.py
+++ b/test.py
@@ -108,3 +108,20 @@ def test_detect_all_and_detect_one_always_agree(enc, txt):
     results = chardet.detect_all(data)
     assert result['encoding'] == results[0]['encoding'], \
         '%s != %s[0]' % (result, results)
+
+
+@pytest.mark.xfail
+@pytest.mark.parametrize('factory', [
+    chardet.utf8prober.UTF8Prober,
+])
+@given(txt=st.text(min_size=1))
+def test_probers_never_enter_error_state_for_own_encoding(factory, txt):
+    # Set up prober and encode text to bytes that it can read
+    prober = factory()
+    try:
+        data = txt.encode(prober.charset_name)
+    except UnicodeEncodeError:
+        reject()
+    # Feed in the bytes and check that it does not rule out the encoding.
+    result = prober.feed(data)
+    assert result != chardet.enums.ProbingState.NOT_ME


### PR DESCRIPTION
This pull request builds on #165 by @hugovk.  In addition to installing Hypothesis so they *can* be run in CI, this PR also:

- Removes the extra code to avoid them when Hypothesis is unavailable
  (i.e. on the no-longer-supported Python 2.6)
- Removes the expensive `xfail` test that has never passed.  This was testing that for any string that does not have a detectable encoding, there is some suffix which when appended will allow an encoding to be detected.
- Adds a test that `UTF8Prober` will never enter an error state on utf-8 encoded text.  This failed on my machine, so it might help @blueyed debug #128?