### PR TITLE
Remove shebang and executable bit from chardet/cli/chardetect.py

### DIFF
--- a/chardet/cli/chardetect.py
+++ b/chardet/cli/chardetect.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """
 Script which takes one or more file paths and reports on their detected
 encodings


### PR DESCRIPTION
The CLI entry point is installed by setuptools through the `console_scripts` option. This setuptools feature automatically constructs a file with a shebang and sets the executable bit. The imported file
`chardet.cli.chardetect` doesn't also require this bit.