### PR TITLE
 Test Python 3.7 and 3.8 and document support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,10 @@ python:
   - 3.4
   - 3.5
   - 3.6
+  - 3.7
+  - 3.8
   - pypy
+  - pypy3
 
 cache:
     directories:

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,11 @@ setup(name='chardet',
                    'Programming Language :: Python :: 3.4',
                    'Programming Language :: Python :: 3.5',
                    'Programming Language :: Python :: 3.6',
+                   'Programming Language :: Python :: 3.7',
+                   'Programming Language :: Python :: 3.8',
+                   ('Programming Language :: Python :: Implementation :: '
+                    'CPython'),
+                   'Programming Language :: Python :: Implementation :: PyPy',
                    ("Topic :: Software Development :: Libraries :: Python "
                     "Modules"),
                    "Topic :: Text Processing :: Linguistic"],

--- a/test.py
+++ b/test.py
@@ -59,7 +59,7 @@ def gen_test_params():
             full_path = join(path, file_name)
             test_case = full_path, encoding
             if full_path in EXPECTED_FAILURES:
-                test_case = pytest.mark.xfail(test_case)
+                test_case = pytest.param(*test_case, marks=pytest.mark.xfail)
             yield test_case
 
 


### PR DESCRIPTION
Use Xenial on Travis to allow Python 3.7. Document that PyPy is also
supported.