### PR TITLE
Remove use of deprecated 'setup.py test'

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
-[aliases]
-test=pytest
-
 [bdist_wheel]
 universal = 1
 

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,6 @@
 #!/usr/bin/env python
 
-import sys
-
 from setuptools import find_packages, setup
-
-
-needs_pytest = {'pytest', 'test', 'ptr'}.intersection(sys.argv)
-pytest_runner = ['pytest-runner'] if needs_pytest else []
 
 
 # Get version without importing, which avoids dependency issues
@@ -54,7 +48,5 @@ setup(name='chardet',
                    "Topic :: Text Processing :: Linguistic"],
       packages=find_packages(),
       python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*",
-      setup_requires=pytest_runner,
-      tests_require=['pytest', 'hypothesis'],
       entry_points={'console_scripts':
                     ['chardetect = chardet.cli.chardetect:main']})


### PR DESCRIPTION
Since setuptools v41.5.0 (27 Oct 2019), the 'test' command is formally
deprecated and should not be used.

The pytest-runner package also lists itself as deprecated:
https://github.com/pytest-dev/pytest-runner

> Deprecation Notice
>
> pytest-runner depends on deprecated features of setuptools and relies
> on features that break security mechanisms in pip. For example
> 'setup_requires' and 'tests_require' bypass pip --require-hashes. See
> also https://github.com/pypa/setuptools/issues/1684.