### PR TITLE
Remove shebang from nonexecutable script

### DIFF
--- a/chardet/cli/chardetect.py
+++ b/chardet/cli/chardetect.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """
 Script which takes one or more file paths and reports on their detected
 encodings


### PR DESCRIPTION
When packaging chardet and pip (which bundles it) in Fedora, we have realized
that there is a nonexecuatble file with a shebang line.

It seems that the primary purpose of this file is to be imported from Python
code or to be executed via `python chardet/cli/chardetect.py` or `python -m
chardet.cli.chardetect` and hence the shebang appears to be unnecessary.

Shebangs are hard to handle when doing downstream packaging, because it makes
sense for upstream to use `#!/usr/bin/env python` while in the RPM package, we
need to avoid that and use a more specific interpreter. Since the shebang was
unused, I propose to remove it to avoid the problems.
