### PR TITLE
Remove deprecated 'sudo: false' from Travis configuraiton

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: python
-sudo: false
 python:
   - 2.7
   - 3.5


### PR DESCRIPTION
https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration