### PR TITLE
Add detect-incrementally function to simply examples

### DIFF
--- a/chardet/__init__.py
+++ b/chardet/__init__.py
@@ -32,12 +32,31 @@ def detect(byte_str):
     if not isinstance(byte_str, bytearray):
         if not isinstance(byte_str, bytes):
             raise TypeError(
-                "Expected object of type bytes or bytearray, got: " f"{type(byte_str)}"
+                f"Expected object of type bytes or bytearray, got: {type(byte_str)}"
             )
         else:
             byte_str = bytearray(byte_str)
     detector = UniversalDetector()
     detector.feed(byte_str)
+    return detector.close()
+
+
+def detect_incrementally(file_object):
+    """
+    Detect the encoding of the given byte string.
+
+    :param file_object:     The file-like object to read from and examine.
+    :type byte_str:      ``file object``
+    """
+    detector = UniversalDetector()
+    try:
+        for line in file_object.readlines():
+            detector.feed(line)
+            if detector.done:
+                break
+    except AttributeError:
+        raise TypeError(f"Expected a file object, got: {type(file_object)}")
+
     return detector.close()
 
 
@@ -55,7 +74,7 @@ def detect_all(byte_str, ignore_threshold=False):
     if not isinstance(byte_str, bytearray):
         if not isinstance(byte_str, bytes):
             raise TypeError(
-                "Expected object of type bytes or bytearray, got: " f"{type(byte_str)}"
+                f"Expected object of type bytes or bytearray, got: {type(byte_str)}"
             )
         else:
             byte_str = bytearray(byte_str)

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -27,18 +27,14 @@ Advanced usage
 --------------
 
 If you’re dealing with a large amount of text, you can call the
-Universal Encoding Detector library incrementally, and it will stop as
+``detect_incrementally`` function, and it will stop as
 soon as it is confident enough to report its results.
 
-Create a ``UniversalDetector`` object, then call its ``feed`` method
-repeatedly with each block of text. If the detector reaches a minimum
-threshold of confidence, it will set ``detector.done`` to ``True``.
-
-Once you’ve exhausted the source text, call ``detector.close()``, which
-will do some final calculations in case the detector didn’t hit its
-minimum confidence threshold earlier. Then ``detector.result`` will be a
+Use the ``with`` keyword to open a file object, then pass that file
+object to the ``detect_incrementally`` function. Once the detector
+reaches a minimum threshold of confidence, it will return a
 dictionary containing the auto-detected character encoding and
-confidence level (the same as the ``chardet.detect`` function 
+confidence level (the same as the ``chardet.detect`` function
 `returns <usage.html#example-using-the-detect-function>`__).
 
 
@@ -48,15 +44,11 @@ Example: Detecting encoding incrementally
 .. code:: python
 
     import urllib.request
-    from chardet.universaldetector import UniversalDetector
+    import chardet
 
-    usock = urllib.request.urlopen('http://yahoo.co.jp/')
-    detector = UniversalDetector()
-    for line in usock.readlines():
-        detector.feed(line)
-        if detector.done: break
-    detector.close()
-    usock.close()
+    with urllib.request.urlopen('http://yahoo.co.jp/') as usock:
+          result = chardet.detect_incrementally(usock)
+
     print(detector.result)
 
 .. code:: python


### PR DESCRIPTION
This function expects a file object, reads it until it is done, then returns the result. I didn't see any reasons why the end user should need to interact with the UniversalDetector directly for this use case.

If this is a PR you would accept, I'd be happy to update tests. However I don't want to go and update them if this will just be rejected anyway.