### PR TITLE
Don't build universal wheels

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
-[bdist_wheel]
-universal = 1
-
 [tool:pytest]
 addopts = -v
 python_files = test.py


### PR DESCRIPTION
Universal wheels are for code expected to work on both Python 2 and 3:

* https://wheel.readthedocs.io/en/stable/user_guide.html#building-wheels