### PR TITLE
Pin Black to its latest version in the .pre-commit-config.yaml file

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 repos:
 - repo: https://github.com/pycqa/isort
-  rev: 5.6.4
+  rev: 5.9.3
   hooks:
   - id: isort
     args: ["--profile", "black"]
     name: isort (python)
-- repo: https://github.com/ambv/black
-  rev: stable
+- repo: https://github.com/psf/black
+  rev: 21.8b0
   hooks:
   - id: black
     language_version: python3.6


### PR DESCRIPTION
Fixes the warning:

    [WARNING] The 'rev' field of repo 'https://github.com/ambv/black'
    appears to be a mutable reference (moving tag / branch). Mutable
    references are never updated after first install and are not
    supported. See
    https://pre-commit.com/#using-the-latest-version-for-a-repository
    for more details. Hint: `pre-commit autoupdate` often fixes this.

Fixed by running the command "pre-commit autoupdate".