### PR TITLE
Remove unnecessary guards for non-falsey values

### DIFF
--- a/chardet/charsetgroupprober.py
+++ b/chardet/charsetgroupprober.py
@@ -40,10 +40,9 @@ class CharSetGroupProber(CharSetProber):
         super().reset()
         self._active_num = 0
         for prober in self.probers:
-            if prober:
-                prober.reset()
-                prober.active = True
-                self._active_num += 1
+            prober.reset()
+            prober.active = True
+            self._active_num += 1
         self._best_guess_prober = None
 
     @property
@@ -64,8 +63,6 @@ class CharSetGroupProber(CharSetProber):
 
     def feed(self, byte_str):
         for prober in self.probers:
-            if not prober:
-                continue
             if not prober.active:
                 continue
             state = prober.feed(byte_str)
@@ -92,8 +89,6 @@ class CharSetGroupProber(CharSetProber):
         best_conf = 0.0
         self._best_guess_prober = None
         for prober in self.probers:
-            if not prober:
-                continue
             if not prober.active:
                 self.logger.debug("%s not active", prober.charset_name)
                 continue

--- a/chardet/escprober.py
+++ b/chardet/escprober.py
@@ -62,8 +62,6 @@ class EscCharSetProber(CharSetProber):
     def reset(self):
         super().reset()
         for coding_sm in self.coding_sm:
-            if not coding_sm:
-                continue
             coding_sm.active = True
             coding_sm.reset()
         self.active_sm_count = len(self.coding_sm)
@@ -87,7 +85,7 @@ class EscCharSetProber(CharSetProber):
     def feed(self, byte_str):
         for c in byte_str:
             for coding_sm in self.coding_sm:
-                if not coding_sm or not coding_sm.active:
+                if not coding_sm.active:
                     continue
                 coding_state = coding_sm.next_state(c)
                 if coding_state == MachineState.ERROR:


### PR DESCRIPTION
The containers:

- CharSetGroupProber.probers
- EscCharSetProber.coding_sm

Never contain falsey values. Can remove the constant guard expressions.