### PR TITLE
Doc/usage: Fix broken link in usage.rst

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -38,8 +38,7 @@ Once you’ve exhausted the source text, call ``detector.close()``, which
 will do some final calculations in case the detector didn’t hit its
 minimum confidence threshold earlier. Then ``detector.result`` will be a
 dictionary containing the auto-detected character encoding and
-confidence level (the same as the ``chardet.detect`` function 
-`returns <usage.html#example-using-the-detect-function>`__).
+confidence level (the same as the ``chardet.detect`` function returns).
 
 
 Example: Detecting encoding incrementally


### PR DESCRIPTION
This PR Fixes broken link in usage.rst.
usage.html#example-using-the-detect-function is valid.

Signed-off-by: Kang Minchul <tegongkang@gmail.com>