### PR TITLE
Update euckrprober to return CP949

### DIFF
--- a/chardet/euckrprober.py
+++ b/chardet/euckrprober.py
@@ -40,7 +40,7 @@ class EUCKRProber(MultiByteCharSetProber):
 
     @property
     def charset_name(self):
-        return "EUC-KR"
+        return "CP949"
 
     @property
     def language(self):


### PR DESCRIPTION
CP949 (aka UHC) is a superset of EUC-KR.

Any EUC-KR file can be treated as being encoded as CP949. If one re-encodes an EUC-KR file as CP949, the file will remain identical to before.

But on occasion, the euckr prober can take a CP949 file and guess that it's EUC-KR, without somehow noticing the occasional words/syllables that can't be printed in EUC-KR, resulting in displaying sporadic placeholders unprintable characters when one opens the file as EUC-KR.

So, this change causes the euckr prober to always return CP949 even if it would otherwise guess EUC-KR, since CP949 covers EUC-KR and more.