### PR TITLE
Clarify LGPL version in License trove classifier

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,7 @@ project_urls =
 classifiers =
     Development Status :: 5 - Production/Stable
     Intended Audience :: Developers
-    License :: OSI Approved :: GNU Library or Lesser General Public License (LGPL)
+    License :: OSI Approved :: GNU Lesser General Public License v2 or later (LGPLv2+)
     Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 3


### PR DESCRIPTION
The [LGPLv2+ trove classifier](https://github.com/pypa/trove-classifiers/blob/3458f52f2d91eb8fc5deab40964a17c5684435db/src/trove_classifiers/__init__.py#L266) reflects the text “`version 2.1 of the License, or (at your option) any later version`” in the source file header comments.