### PR TITLE
Remove support for EOL Python 3.6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10-dev", "pypy3.9"]
+        python-version: ["3.7", "3.8", "3.9", "3.10-dev", "pypy3.9"]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,9 +7,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
+      with:
+        python-version: 3.x
     - name: Install dependencies
       run: python -m pip install pre-commit
     - name: Run pre-commit
@@ -19,12 +21,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10-dev", "pypy3"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10-dev", "pypy3.9"]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,7 @@ Detects
    Our ISO-8859-2 and windows-1250 (Hungarian) probers have been temporarily
    disabled until we can retrain the models.
 
-Requires Python 3.6+.
+Requires Python 3.7+.
 
 Installation
 ------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,6 @@ classifiers =
     Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -32,7 +31,7 @@ classifiers =
     Topic :: Text Processing :: Linguistic
 
 [options]
-python_requires = >=3.6
+python_requires = >=3.7
 packages = find:
 
 [options.entry_points]


### PR DESCRIPTION
Python 3.6 went EOL on 2021-12-23. It is no longer receiving bug fixes,
including for security issues.

Remove the testing resources and support for EOL Pythons.

https://devguide.python.org/devcycle/#end-of-life-branches