### PR TITLE
Remove setup.py in favor of build package

### DIFF
--- a/chardet/version.py
+++ b/chardet/version.py
@@ -1,6 +1,6 @@
 """
 This module exists only to simplify retrieving the version number of chardet
-from within setup.py and from chardet subpackages.
+from within setuptools and from chardet subpackages.
 
 :author: Dan Blanchard (dan.blanchard@gmail.com)
 """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,0 @@
-from setuptools import setup
-
-setup()


### PR DESCRIPTION
setuptool no longer recommends using setup.py. Instead, build the
package using:

    python -m build

The command builds both the sdist and wheel.

For additional information, see:
https://setuptools.pypa.io/en/latest/userguide/quickstart.html