### PR TITLE
Add should_rename_legacy flag to allow WHATWG-inspired renaming

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,8 @@
 name: Python package
 
-on: [push, pull_request]
+on:
+  workflow_dispatch:
+  pull_request:
 
 jobs:
   lint:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           python-version: 3.x
       - name: Install dependencies
-        run: python -m pip install pre-commit
+        run: python -m pip install pre-commit pytest hypothesis
       - name: Run pre-commit
         run: pre-commit run --all-files
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           python-version: 3.x
       - name: Install dependencies
-        run: python -m pip install pre-commit pytest hypothesis
+        run: python -m pip install pre-commit
       - name: Run pre-commit
         run: pre-commit run --all-files
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
         args: ["--profile", "black"]
         name: isort (python)
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 22.6.0
     hooks:
       - id: black
         args: ["--target-version", "py36"]

--- a/chardet/cli/chardetect.py
+++ b/chardet/cli/chardetect.py
@@ -22,7 +22,10 @@ from ..universaldetector import UniversalDetector
 
 
 def description_of(
-    lines: Iterable[bytes], name: str = "stdin", minimal: bool = False
+    lines: Iterable[bytes],
+    name: str = "stdin",
+    minimal: bool = False,
+    should_rename_legacy: bool = False,
 ) -> Optional[str]:
     """
     Return a string describing the probable encoding of a file or
@@ -32,8 +35,11 @@ def description_of(
     :type lines: Iterable of bytes
     :param name: Name of file or collection of lines
     :type name: str
+    :param should_rename_legacy:  Should we rename legacy encodings to
+                                  their more modern equivalents?
+    :type should_rename_legacy:   ``bool``
     """
-    u = UniversalDetector()
+    u = UniversalDetector(should_rename_legacy=should_rename_legacy)
     for line in lines:
         line = bytearray(line)
         u.feed(line)
@@ -76,6 +82,12 @@ def main(argv: Optional[List[str]] = None) -> None:
         action="store_true",
     )
     parser.add_argument(
+        "-l",
+        "--legacy",
+        help="Rename legacy encodings to more modern ones.",
+        action="store_true",
+    )
+    parser.add_argument(
         "--version", action="version", version=f"%(prog)s {__version__}"
     )
     args = parser.parse_args(argv)
@@ -89,7 +101,11 @@ def main(argv: Optional[List[str]] = None) -> None:
                 "--help\n",
                 file=sys.stderr,
             )
-        print(description_of(f, f.name, minimal=args.minimal))
+        print(
+            description_of(
+                f, f.name, minimal=args.minimal, should_rename_legacy=args.legacy
+            )
+        )
 
 
 if __name__ == "__main__":

--- a/chardet/universaldetector.py
+++ b/chardet/universaldetector.py
@@ -329,7 +329,7 @@ class UniversalDetector:
                 # Rename legacy encodings with superset encodings if asked
                 if self.should_rename_legacy:
                     charset_name = self.LEGACY_MAP.get(
-                        charset_name.lower(), charset_name
+                        (charset_name or "").lower(), charset_name
                     )
                 self.result = {
                     "encoding": charset_name,

--- a/test.py
+++ b/test.py
@@ -20,7 +20,7 @@ try:
     HAVE_HYPOTHESIS = True
 except ImportError:
     HAVE_HYPOTHESIS = False
-import pytest
+import pytest  # pylint: disable=import-error
 
 import chardet
 from chardet.metadata.languages import LANGUAGES


### PR DESCRIPTION
This PR adds a new `should_rename_legacy` flag, so that people can opt into renaming legacy encodings according to the W3C offshoot WHATWG group's suggested mapping [here](https://encoding.spec.whatwg.org/#names-and-labels). This should address long-standing complaint about us returning `gb2312` instead of at least `gbk`, and things like that. One interesting side effect of this change is that they suggest mapping ASCII and ISO-8859-1 to Windows-1252, so we will return Windows-1252 a lot more often with this flag on.