### PR TITLE
Add chunk_size parameter and iterate by chunks by default

### DIFF
--- a/chardet/charsetprober.py
+++ b/chardet/charsetprober.py
@@ -33,12 +33,11 @@ from typing import Optional, Union
 from .enums import LanguageFilter, ProbingState
 
 INTERNATIONAL_WORDS_PATTERN = re.compile(
-    b"[a-zA-Z]*[\x80-\xFF]+[a-zA-Z]*[^a-zA-Z\x80-\xFF]?"
+    b"(?:[a-zA-Z]*)(?:[\x80-\xFF]+)(?:[a-zA-Z]*)(?:[^a-zA-Z\x80-\xFF]?)"
 )
 
 
 class CharSetProber:
-
     SHORTCUT_THRESHOLD = 0.95
 
     def __init__(self, lang_filter: LanguageFilter = LanguageFilter.NONE) -> None:

--- a/chardet/charsetprober.py
+++ b/chardet/charsetprober.py
@@ -100,7 +100,7 @@ class CharSetProber:
             # similarly across all languages and may thus have similar
             # frequencies).
             last_char = word[-1:]
-            if not last_char.isalpha() and last_char < b"\x80":
+            if last_char < b"\x80" and not last_char.isalpha():
                 last_char = b" "
             filtered.extend(last_char)
 

--- a/chardet/cli/chardetect.py
+++ b/chardet/cli/chardetect.py
@@ -26,6 +26,7 @@ def description_of(
     name: str = "stdin",
     minimal: bool = False,
     should_rename_legacy: bool = False,
+    chunk_size: int = 16384,
 ) -> Optional[str]:
     """
     Return a string describing the probable encoding of a file or
@@ -38,14 +39,33 @@ def description_of(
     :param should_rename_legacy:  Should we rename legacy encodings to
                                   their more modern equivalents?
     :type should_rename_legacy:   ``bool``
+    ::param chunk_size: The number of bytes to be examined at one time.
+                        After each chunk the detector checks if it is finished.
+                        If 0, the lines is checked by line.
+                        Default is 16384.
+    :type chunk_size:   ``int``
     """
     u = UniversalDetector(should_rename_legacy=should_rename_legacy)
-    for line in lines:
-        line = bytearray(line)
-        u.feed(line)
-        # shortcut out of the loop to save reading further - particularly useful if we read a BOM.
-        if u.done:
-            break
+
+    # If the chunk size is greater than 0, process the lines in chunks
+    if chunk_size > 0:
+        chunk = bytearray()
+        for line in lines:
+            chunk += line
+            # If the chunk size is reached, feed it to the detector and reset the chunk
+            if len(chunk) >= chunk_size:
+                u.feed(chunk)
+                chunk = bytearray()
+            if u.done:
+                break
+    else:
+        # Process the lines one by one
+        for line in lines:
+            u.feed(bytearray(line))
+            # shortcut out of the loop to save reading further - particularly useful if we read a BOM.
+            if u.done:
+                break
+
     u.close()
     result = u.result
     if minimal:
@@ -88,6 +108,14 @@ def main(argv: Optional[List[str]] = None) -> None:
         action="store_true",
     )
     parser.add_argument(
+        "-c",
+        "--chunk-size",
+        help="""The number of bytes to be examined at one time. 
+                If 0, the lines are checked by line. Default is 16384.""",
+        type=int,
+        default=16384,
+    )
+    parser.add_argument(
         "--version", action="version", version=f"%(prog)s {__version__}"
     )
     args = parser.parse_args(argv)
@@ -103,7 +131,11 @@ def main(argv: Optional[List[str]] = None) -> None:
             )
         print(
             description_of(
-                f, f.name, minimal=args.minimal, should_rename_legacy=args.legacy
+                f,
+                f.name,
+                minimal=args.minimal,
+                should_rename_legacy=args.legacy,
+                chunk_size=args.chunk_size,
             )
         )
 


### PR DESCRIPTION
**Add chunk_size parameter and iterate by chunks by default to improve performance and low memory consumption.**

detect() processes all incoming bytes at once, which leads to performance degradation and increased memory consumption when processing large files.
___
memory-profiler results:
```python3
mprof run bench.py
mprof plot
```
before
![before](https://github.com/chardet/chardet/assets/65482418/27cf7e5b-6b97-49fd-aa31-5344bc472dce)
after
![after_chunk16384](https://github.com/chardet/chardet/assets/65482418/5b7d1396-d616-4c0f-9657-b7ca0d06d382)
___
bench.py results
before
```python3
Calls per second for each encoding:
ascii: 2447.037591645437
big5: 35.51794139326065
cp932: 12.423507221195562
cp949: 21.244845560559376
euc-jp: 12.328510174196076
euc-kr: 35.59465724220593
euc-tw: 272.6406656266251
gb2312: 39.814863859931705
ibm855: 73.3086160122448
ibm866: 90.1158594541804
iso-2022-jp: 2349.7501400560222
iso-2022-kr: 1553.2158198785364
iso-8859-1: 254.33820163058144
iso-8859-2-croatian: 82.71810042204078
iso-8859-2-czech: 209.77918265070846
iso-8859-2-polish: 126.04175243636014
iso-8859-2-slovak: 117.66268267743153
iso-8859-2-slovene: 108.08585425186766
iso-8859-5: 88.61599269306654
iso-8859-5-russian: 94.23265836359697
iso-8859-7: 157.81893267349142
iso-8859-9: 211.43682434220642
johab: 40.16530999134635
koi8-r: 83.07685329510834
maccyrillic: 83.47851823198715
macroman: 0.39496194284516384
shift_jis: 13.63912487563005
tis-620: 38.75953227639994
utf-16: 128857.26574500768
utf-16be: 631.3965286245465
utf-16le: 288.9007208218678
utf-32: 116025.00691562932
utf-32be: 309.48448815905493
utf-32le: 246.41067819711427
utf-8: 234.9924054529762
utf-8-sig: 103948.05452292442
windows-1250-croatian: 82.62115019058218
windows-1250-czech: 217.7473555789173
windows-1250-polish: 87.21616771572168
windows-1250-romanian: 134.06200157896586
windows-1250-slovak: 150.2474927729531
windows-1250-slovene: 184.95116390847477
windows-1251: 97.17230326728034
windows-1251-russian: 115.7745791769917
windows-1252: 208.4121033239669
windows-1255: 37.29806542149806

Total time: 122.76112413406372s (32.09485110039596 calls per second)
```
after
```python3
Calls per second for each encoding:
ascii: 2476.8049130956833
big5: 49.78024448543349
cp932: 13.021275855945579
cp949: 31.89223426395032
euc-jp: 14.197576474056692
euc-kr: 39.11454957647627
euc-tw: 137.2293074904627
gb2312: 56.40991190456737
ibm855: 94.70197107115405
ibm866: 98.19944572035737
iso-2022-jp: 2089.837568510214
iso-2022-kr: 3741.9073958426266
iso-8859-1: 148.44133736163525
iso-8859-2-croatian: 82.23351527699354
iso-8859-2-czech: 208.8916446908065
iso-8859-2-polish: 113.80463596823252
iso-8859-2-slovak: 195.12792420615813
iso-8859-2-slovene: 77.14215824215438
iso-8859-5: 87.02954707278576
iso-8859-5-russian: 116.23301882653065
iso-8859-7: 158.69412369048712
iso-8859-9: 209.76974013243444
johab: 83.13333535943212
koi8-r: 120.88019418972694
maccyrillic: 112.3811015853227
macroman: 0.4683798978905325
shift_jis: 14.110488194121753
tis-620: 37.65504084461838
utf-16: 148208.6219081272
utf-16be: 675.0579809278557
utf-16le: 712.2147696592009
utf-32: 95216.88989784336
utf-32be: 241.8483857761479
utf-32le: 227.94449078967747
utf-8: 277.53292691633277
utf-8-sig: 161630.21194605008
windows-1250-croatian: 83.79926396253481
windows-1250-czech: 210.96145479419673
windows-1250-polish: 124.81896015546185
windows-1250-romanian: 131.0179550935239
windows-1250-slovak: 234.03102332328982
windows-1250-slovene: 114.11364285617118
windows-1251: 98.32621942106839
windows-1251-russian: 133.77635053356587
windows-1252: 209.6879405677262
windows-1255: 70.53436610314138

Total time: 104.45148515701294s (37.72086145139379 calls per second)
```