### PR TITLE
Update pyproject.toml to usre valid License text

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = []
 description = "Universal encoding detector for Python 3"
 dynamic = ["version"]
 keywords = ["encoding", "i18n", "xml"]
-license = { text = "LGPL" }
+license = { text = "LGPL-2.1-or-later" }
 maintainers = [
     { name = "Dan Blanchard", email = "dan.blanchard@gmail.com" },
     { name = "Ian Cordasco" },


### PR DESCRIPTION
LGPL-2.1-or-later is the correct setting for LGPL 2.1 or later.

https://python-poetry.org/docs/pyproject/#license
https://spdx.org/licenses/

The propesed change will make the license readable for audit tool and other application that have strict expectations on what to expect.