### PR TITLE
Pass max_bytes parameter to UniversalDetector in detect() and detect_all()

### DIFF
--- a/chardet/__init__.py
+++ b/chardet/__init__.py
@@ -62,7 +62,9 @@ def detect(
         should_rename_legacy = encoding_era == EncodingEra.MODERN_WEB
 
     detector = UniversalDetector(
-        should_rename_legacy=should_rename_legacy, encoding_era=encoding_era
+        should_rename_legacy=should_rename_legacy,
+        encoding_era=encoding_era,
+        max_bytes=max_bytes,
     )
 
     # Process in chunks like uchardet does
@@ -116,7 +118,9 @@ def detect_all(
         should_rename_legacy = encoding_era == EncodingEra.MODERN_WEB
 
     detector = UniversalDetector(
-        should_rename_legacy=should_rename_legacy, encoding_era=encoding_era
+        should_rename_legacy=should_rename_legacy,
+        encoding_era=encoding_era,
+        max_bytes=max_bytes,
     )
 
     # Process in chunks like uchardet does


### PR DESCRIPTION
`detect()` and `detect_all()` both accept a `max_bytes` parameter, but neither passes it to the `UniversalDetector` constructor. The detector always uses the default value of 200,000 regardless of what the caller specifies.

```python
# Before: max_bytes is accepted but silently ignored
result = chardet.detect(large_data, max_bytes=1000)
# Still examines up to 200,000 bytes

# After: max_bytes is properly forwarded
result = chardet.detect(large_data, max_bytes=1000)
# Now actually limits examination to 1000 bytes
```
