### PR TITLE
Fix code scanning alert: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,8 @@
 name: Python package
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/chardet/chardet/security/code-scanning/2](https://github.com/chardet/chardet/security/code-scanning/2)

In general, the fix is to explicitly define a `permissions:` block that restricts the `GITHUB_TOKEN` to the least privileges needed. For this workflow, all steps only read the repository contents and run local commands; they do not need to write to the repository or interact with issues/PRs. Therefore, setting `contents: read` at the workflow level is sufficient and does not change any existing behavior, assuming the workflow already functioned with the default permissions.

The best way to fix this with minimal change is to add a root-level `permissions:` block under the workflow name and before `on:`. This block will apply to all jobs in the workflow that don’t override it, so both `lint` and `build` will use these restricted permissions. Specifically, in `.github/workflows/test.yml`, after line 1 (`name: Python package`) insert:

```yaml
permissions:
  contents: read
```

No additional imports, methods, or other code changes are needed, because permissions are a native part of the GitHub Actions workflow syntax.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
