### PR TITLE
ci: add riscv64 wheel builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
         if: runner.os == 'Linux'
         uses: docker/setup-qemu-action@v3
         with:
-          platforms: arm64
+          platforms: arm64,riscv64
       - uses: astral-sh/setup-uv@v7
       - uses: pypa/cibuildwheel@v3.3
         env:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -210,7 +210,7 @@ build-frontend = "build[uv]"
 test-command = "python -c \"import chardet; print(chardet.detect(b'hello world'))\""
 
 [tool.cibuildwheel.linux]
-archs = ["x86_64", "aarch64"]
+archs = ["x86_64", "aarch64", "riscv64"]
 
 [tool.cibuildwheel.macos]
 archs = ["x86_64", "arm64"]


### PR DESCRIPTION
## What does this change?

Add riscv64 to the cibuildwheel wheel build matrix and QEMU platforms, so that mypyc-compiled riscv64 wheels are published alongside existing architectures.

## Changes

- Add `riscv64` to `archs` list in `pyproject.toml` (`[tool.cibuildwheel.linux]`)
- Add `riscv64` to QEMU platforms in `release.yml`

## Evidence

- Built successfully from source on native riscv64 hardware (BananaPi F3, SpacemiT K1, rv64gc)

---

Note: this work is part of the [RISE Project](https://riseproject.dev/) effort to improve Python ecosystem support on riscv64 platforms. Native riscv64 CI runners are available for free via [RISE RISC-V runners](https://github.com/apps/rise-risc-v-runners).