### PR TITLE
Return utf-16/utf-32 (not -le/-be) when a BOM is present

### DIFF
--- a/src/chardet/pipeline/bom.py
+++ b/src/chardet/pipeline/bom.py
@@ -7,11 +7,11 @@ from chardet.pipeline import DetectionResult
 # Ordered longest-first so UTF-32 is checked before UTF-16
 # (UTF-32-LE BOM starts with the same bytes as UTF-16-LE BOM)
 _BOMS: tuple[tuple[bytes, str], ...] = (
-    (b"\x00\x00\xfe\xff", "utf-32-be"),
-    (b"\xff\xfe\x00\x00", "utf-32-le"),
+    (b"\x00\x00\xfe\xff", "utf-32"),
+    (b"\xff\xfe\x00\x00", "utf-32"),
     (b"\xef\xbb\xbf", "utf-8-sig"),
-    (b"\xfe\xff", "utf-16-be"),
-    (b"\xff\xfe", "utf-16-le"),
+    (b"\xfe\xff", "utf-16"),
+    (b"\xff\xfe", "utf-16"),
 )
 
 _UTF32_BOMS: frozenset[bytes] = frozenset({b"\x00\x00\xfe\xff", b"\xff\xfe\x00\x00"})

--- a/tests/test_bom.py
+++ b/tests/test_bom.py
@@ -14,25 +14,25 @@ def test_utf8_bom():
 def test_utf16_le_bom():
     data = b"\xff\xfeH\x00e\x00l\x00l\x00o\x00"
     result = detect_bom(data)
-    assert result == DetectionResult("utf-16-le", 1.0, None)
+    assert result == DetectionResult("utf-16", 1.0, None)
 
 
 def test_utf16_be_bom():
     data = b"\xfe\xff\x00H\x00e\x00l\x00l\x00o"
     result = detect_bom(data)
-    assert result == DetectionResult("utf-16-be", 1.0, None)
+    assert result == DetectionResult("utf-16", 1.0, None)
 
 
 def test_utf32_le_bom():
     data = b"\xff\xfe\x00\x00" + b"\x48\x00\x00\x00"
     result = detect_bom(data)
-    assert result == DetectionResult("utf-32-le", 1.0, None)
+    assert result == DetectionResult("utf-32", 1.0, None)
 
 
 def test_utf32_be_bom():
     data = b"\x00\x00\xfe\xff" + b"\x00\x00\x00\x48"
     result = detect_bom(data)
-    assert result == DetectionResult("utf-32-be", 1.0, None)
+    assert result == DetectionResult("utf-32", 1.0, None)
 
 
 def test_no_bom():
@@ -55,14 +55,14 @@ def test_utf32_le_checked_before_utf16_le():
     data = b"\xff\xfe\x00\x00" + b"\x48\x00\x00\x00"
     result = detect_bom(data)
     assert result is not None
-    assert result.encoding == "utf-32-le"
+    assert result.encoding == "utf-32"
 
 
 def test_utf32_le_bom_only():
     # Bare UTF-32-LE BOM with no payload is valid (0 % 4 == 0)
     result = detect_bom(b"\xff\xfe\x00\x00")
     assert result is not None
-    assert result.encoding == "utf-32-le"
+    assert result.encoding == "utf-32"
 
 
 def test_utf32_le_bom_falls_through_to_utf16_when_payload_not_aligned():
@@ -72,7 +72,7 @@ def test_utf32_le_bom_falls_through_to_utf16_when_payload_not_aligned():
     data = b"\xff\xfe\x00\x000\x00"
     result = detect_bom(data)
     assert result is not None
-    assert result.encoding == "utf-16-le"
+    assert result.encoding == "utf-16"
 
 
 def test_utf32_be_bom_falls_through_when_payload_not_aligned():

--- a/tests/test_github_issues.py
+++ b/tests/test_github_issues.py
@@ -208,6 +208,25 @@ class TestUtf1632:
         """Issue #62: UTF-16 BOM + U+0000 + U+0030 misread as UTF-32-LE."""
         _assert_detection(b"\xff\xfe\x00\x000\x00", "utf-16")
 
+    def test_utf16_le_bom_returns_utf16(self) -> None:
+        """Issue #364: BOM-prefixed UTF-16 should return 'utf-16' (not -le/-be).
+
+        Python's 'utf-16' codec strips the BOM on decode; 'utf-16-le' does not.
+        """
+        _assert_detection(b"\xff\xfeH\x00e\x00l\x00l\x00o\x00", "utf-16")
+
+    def test_utf16_be_bom_returns_utf16(self) -> None:
+        """Issue #364: BOM-prefixed UTF-16-BE should return 'utf-16'."""
+        _assert_detection(b"\xfe\xff\x00H\x00e\x00l\x00l\x00o", "utf-16")
+
+    def test_utf32_le_bom_returns_utf32(self) -> None:
+        """Issue #364: BOM-prefixed UTF-32 should return 'utf-32'."""
+        _assert_detection(b"\xff\xfe\x00\x00H\x00\x00\x00", "utf-32")
+
+    def test_utf32_be_bom_returns_utf32(self) -> None:
+        """Issue #364: BOM-prefixed UTF-32-BE should return 'utf-32'."""
+        _assert_detection(b"\x00\x00\xfe\xff\x00\x00\x00H", "utf-32")
+
     def test_utf16le_no_bom(self) -> None:
         """Issue #105: UTF-16LE without BOM detected via null-byte pattern."""
         _assert_detection(

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -23,28 +23,28 @@ def test_bom_detected():
 def test_bom_utf16_le():
     data = b"\xff\xfe" + "Hello world".encode("utf-16-le")
     result = run_pipeline(data, EncodingEra.ALL)
-    assert result[0].encoding == "utf-16-le"
+    assert result[0].encoding == "utf-16"
     assert result[0].confidence == 1.0
 
 
 def test_bom_utf16_be():
     data = b"\xfe\xff" + "Hello world".encode("utf-16-be")
     result = run_pipeline(data, EncodingEra.ALL)
-    assert result[0].encoding == "utf-16-be"
+    assert result[0].encoding == "utf-16"
     assert result[0].confidence == 1.0
 
 
 def test_bom_utf32_le():
     data = b"\xff\xfe\x00\x00" + "Hello world".encode("utf-32-le")
     result = run_pipeline(data, EncodingEra.ALL)
-    assert result[0].encoding == "utf-32-le"
+    assert result[0].encoding == "utf-32"
     assert result[0].confidence == 1.0
 
 
 def test_bom_utf32_be():
     data = b"\x00\x00\xfe\xff" + "Hello world".encode("utf-32-be")
     result = run_pipeline(data, EncodingEra.ALL)
-    assert result[0].encoding == "utf-32-be"
+    assert result[0].encoding == "utf-32"
     assert result[0].confidence == 1.0
 
 


### PR DESCRIPTION
## Summary

Fixes #364. After the v7 rewrite, the BOM stage started returning the endian-specific names (`utf-16-le`, `utf-16-be`, `utf-32-le`, `utf-32-be`) for BOM-prefixed input. The problem: Python's `utf-16-le` codec keeps the BOM as a literal U+FEFF in the decoded string, while `utf-16` strips it. So anyone who took our detection result and passed it straight to `.decode()` ended up with a stray BOM at the start of their text.

The fix is small: when the BOM stage matches a UTF-16 or UTF-32 BOM, return `utf-16` / `utf-32` instead of the endian-specific variant. BOM-less detection (the null-byte pattern stuff in `pipeline/utf1632.py`) still returns the endian-specific name, which is correct since there's no BOM for Python to strip in that case.

I verified the codec behavior across all our supported Python versions (3.10 through 3.14) before committing. `utf-16`, `utf-32`, and `utf-8-sig` all strip the BOM, the `-le`/`-be` variants do not, and `utf-8` keeps it. Same on every version, no surprises.

## Test plan

- Added 4 regression tests in `tests/test_github_issues.py` covering UTF-16-LE/BE and UTF-32-LE/BE BOM inputs
- Updated existing BOM expectations in `tests/test_bom.py` and `tests/test_orchestrator.py` (the BOM-less orchestrator tests are unchanged)
- Full unit suite passes locally (826 tests)
- Accuracy suite passes (7523 passed, 28 xfailed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)