### PR TITLE
Fix RuntimeError on ~2% of two-byte inputs

### DIFF
--- a/src/chardet/pipeline/orchestrator.py
+++ b/src/chardet/pipeline/orchestrator.py
@@ -725,7 +725,8 @@ def _run_pipeline_core(  # noqa: PLR0913
             results = _score_structural_candidates(
                 data, structural_scores, valid_candidates, ctx
             )
-            return _postprocess_results(data, results)
+            if results:
+                return _postprocess_results(data, results)
 
     # Stage 3: Statistical scoring for all remaining candidates.
     # Bigram models converge quickly and don't benefit from scanning

--- a/tests/test_github_issues.py
+++ b/tests/test_github_issues.py
@@ -445,6 +445,39 @@ class TestNoCrash:
         assert isinstance(result, dict)
         assert "encoding" in result
 
+    def test_issue_367_short_two_byte_runtime_error(self) -> None:
+        r"""Issue #367: b'\xf9\x92' raised RuntimeError.
+
+        Two-byte sequences that are valid multi-byte (e.g. cp932) score
+        above the structural confidence threshold, but statistical scoring
+        returns no results due to insufficient data.  The pipeline must
+        fall through to the fallback instead of returning an empty list.
+        """
+        # The exact input from the bug report
+        result = chardet.detect(b"\xf9\x92")
+        assert isinstance(result, dict)
+        assert "encoding" in result
+        assert result["encoding"] is not None
+
+    def test_issue_367_additional_two_byte_sequences(self) -> None:
+        """Issue #367: verify other representative two-byte sequences don't crash.
+
+        Samples chosen from byte ranges that form valid cp932/johab multi-byte
+        sequences — the same structural path that triggered the original bug.
+        """
+        samples = [
+            b"\x81\x40",  # cp932 lead byte + valid trail
+            b"\xf0\x80",  # cp932 high lead byte
+            b"\xe0\xa0",  # cp932 lead byte
+            b"\x84\x41",  # johab lead byte
+            b"\xd9\xfe",  # johab high lead byte
+            b"\xf9\x92",  # original report
+        ]
+        for data in samples:
+            result = chardet.detect(data)
+            assert isinstance(result, dict), f"Failed on {data!r}"
+            assert "encoding" in result, f"Failed on {data!r}"
+
 
 # =========================================================================
 # NULL SEPARATOR ISSUES

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -372,3 +372,19 @@ def test_fallback_when_cjk_gate_eliminates_all(monkeypatch: pytest.MonkeyPatch):
     data = bytes(range(0x80, 0x100)) * 2
     result = run_pipeline(data, EncodingEra.ALL)
     assert result[0].encoding is not None  # fallback
+
+
+def test_fallback_when_structural_scores_high_but_statistical_empty():
+    """Fall through to fallback when structural scores high but statistical empty.
+
+    When structural scoring exceeds the threshold but statistical scoring
+    returns no results (e.g. very short inputs), fall through to the
+    no_match_encoding fallback instead of returning an empty list.
+
+    Regression test for GitHub issue #367.
+    """
+    # b"\xf9\x92" is a valid cp932 multi-byte sequence that scores 1.0
+    # structurally but yields no statistical bigram matches on 2 bytes.
+    result = run_pipeline(b"\xf9\x92", EncodingEra.ALL)
+    assert len(result) >= 1
+    assert result[0].encoding is not None


### PR DESCRIPTION
## Summary

- Fix `RuntimeError: pipeline must always return at least one result` that occurs on ~2.1% of all possible two-byte inputs (e.g. `b"\xf9\x92"`)
- When multi-byte encodings (cp932, johab) score above the structural confidence threshold but statistical scoring returns zero results (common with very short inputs), the pipeline returned an empty list instead of falling through to the fallback path
- Guard the early return in `_run_pipeline_core` so empty structural results fall through to Stage 3 statistical scoring, which has its own fallback to `no_match_encoding`

Fixes #367

## Test plan

- [x] Verified `chardet.detect(b"\xf9\x92")` no longer raises (returns `cp1252` at 0.10 confidence)
- [x] Verified 0/65536 two-byte sequences crash (was ~1,370 / 2.1%)
- [x] Full test suite passes (9224 passed, 28 xfailed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)