### PR TITLE
Fix "+<digits>" ASCII text misdetected as UTF-7 (#371)

### DIFF
--- a/src/chardet/pipeline/escape.py
+++ b/src/chardet/pipeline/escape.py
@@ -43,6 +43,9 @@ def _has_valid_hz_regions(data: bytes) -> bool:
 _B64_CHARS: bytes = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
 _UTF7_BASE64: frozenset[int] = frozenset(_B64_CHARS)
 
+# Uppercase ASCII letters (A-Z), used by Guard C in _has_valid_utf7_sequences.
+_B64_UPPERCASE: frozenset[int] = frozenset(b"ABCDEFGHIJKLMNOPQRSTUVWXYZ")
+
 # Lookup table mapping each Base64 byte to its 6-bit value (0-63).
 _B64_DECODE: dict[int, int] = {c: i for i, c in enumerate(_B64_CHARS)}
 
@@ -175,13 +178,16 @@ def _has_valid_utf7_sequences(data: bytes) -> bool:
         # UTF-7 encodes UTF-16BE code points, and the high byte for virtually
         # every script (Latin Extended, Cyrillic, Arabic, CJK, …) produces
         # uppercase base64 characters.  Sequences without any uppercase like
-        # "row", "foo", "pos" are almost always variable names or English
-        # words that accidentally follow a '+'.  (bytes.islower() returns
-        # True when there are no uppercase letters, even if digits or '/'
-        # are present, which is the desired behavior here.)  Out of 71,510
-        # real UTF-7 base64 blocks in the test corpus, only 4 lack uppercase
-        # letters (0.006%).
-        if b64_len >= 3 and b64_data.islower():
+        # "row", "foo", "pos" (variable names / English words) or "100", "99"
+        # (digit runs) are almost always ASCII text that accidentally follows a
+        # '+'.  Out of 71,510 real UTF-7 base64 blocks in the test corpus, only
+        # 4 lack uppercase letters (0.006%).
+        #
+        # NOTE: this must test for the *absence of uppercase letters*, not
+        # ``bytes.islower()``.  ``b"100".islower()`` is ``False`` (there are no
+        # cased characters at all), so an all-digit run like ``+100`` would slip
+        # through an ``islower()`` guard and be misdetected as UTF-7 (issue #371).
+        if b64_len >= 3 and not any(b in _B64_UPPERCASE for b in b64_data):
             start = i
             continue
         # Accept if base64 content is valid UTF-16BE (padding bits check

--- a/tests/test_github_issues.py
+++ b/tests/test_github_issues.py
@@ -195,6 +195,24 @@ class TestEscapeSequences:
         # With enough ASCII bytes, the single ESC should not trigger binary
         _assert_detection(b"0" * 100 + b"\x1b", "ascii")
 
+    def test_plus_digits_not_utf7(self) -> None:
+        """Issue #371: ASCII text with a "+<digits>" run misdetected as UTF-7.
+
+        UTF-7 Guard C rejects base64 runs with no uppercase letters, but it
+        used ``bytes.islower()`` which is ``False`` for an all-digit run like
+        ``100`` (no cased characters), letting ``+100`` slip through and decode
+        as a valid UTF-16BE code unit.  Such a run has no uppercase letters and
+        must be treated as plain ASCII.
+        """
+        text = (
+            b"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do "
+            b"eiusmod tempor incididunt ut labore et dolore magna aliqua.\n\n+100\n"
+        )
+        _assert_detection(text, "ascii")
+        # Other digit-only runs after '+' must also stay ASCII.
+        for run in (b"+200", b"+99", b"+2000000"):
+            _assert_detection(b"the value is " + run + b" units\n", "ascii")
+
 
 # =========================================================================
 # UTF-16 / UTF-32 ISSUES


### PR DESCRIPTION
Fixes #371

## The bug

An otherwise-ASCII document containing a `+` immediately followed by digits (e.g. `+100`) is detected as **utf-7** with 0.95 confidence instead of **ascii**. Removing the `+100` makes it detect as ASCII again.

Reproduction (from the issue):

```python
import chardet
data = (b"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do "
        b"eiusmod tempor incididunt ut labore et dolore magna aliqua.\n\n+100\n")
chardet.detect(data)
# before: {'encoding': 'utf-7', 'confidence': 0.95, ...}
# after:  {'encoding': 'ascii', 'confidence': 1.0,  ...}
```

## Root cause

`_has_valid_utf7_sequences` in `src/chardet/pipeline/escape.py` has a **Guard C** whose stated intent is to *"reject base64 blocks with no uppercase letters"* — real UTF-7 encodes UTF-16BE code points whose high bytes almost always yield uppercase base64 characters, so a `+<run>` with no uppercase is almost certainly ASCII text that happens to follow a `+`.

The guard implemented this as:

```python
if b64_len >= 3 and b64_data.islower():
    start = i
    continue
```

But `bytes.islower()` returns `True` only when there is **at least one cased character** and all cased characters are lowercase. For an all-digit run there are **no cased characters**, so:

```python
b"row".islower()  # True  -> skipped (correct)
b"100".islower()  # False -> NOT skipped  <-- the bug
```

So `+100` bypasses Guard C, then passes `_is_valid_utf7_b64` (`100` decodes to a single valid UTF-16BE code unit with zero padding bits), and the whole document is reported as UTF-7.

## The fix

Test Guard C for the condition it actually documents — the **absence of uppercase ASCII letters** — rather than `islower()`:

```python
if b64_len >= 3 and not any(b in _B64_UPPERCASE for b in b64_data):
    start = i
    continue
```

This rejects digit-only runs (`100`, `99`) **and** the lowercase-word runs (`row`, `foo`) the guard already handled, while still admitting genuine UTF-7 base64 (which contains uppercase). Guard C only becomes *stricter* for letter-less runs, so real UTF-7 detection is unaffected.

| input | base64 run | `islower()` (old) | `no uppercase` (new) | intended |
|-------|-----------|-------------------|----------------------|----------|
| `+100` | `100` | `False` → kept (bug) | `True` → rejected | reject |
| `+99`  | `99`  | `False` → kept (bug) | `True` → rejected | reject |
| `+row` | `row` | `True` → rejected | `True` → rejected | reject |
| `+D7A…` (real UTF-7) | `D7A…` | `False` → kept | `False` → kept | keep |

## Tests

Added `TestEscapeSequences.test_plus_digits_not_utf7` in `tests/test_github_issues.py`, covering the reported `+100` document and other `+<digits>` runs.

Proven to guard the bug (stash the source fix, keep the test):

```
# without the fix
FAILED tests/test_github_issues.py::TestEscapeSequences::test_plus_digits_not_utf7
# with the fix
1 passed
```

Full suite is green: **9242 passed, 28 xfailed**. `ruff check`, `ruff format --check`, and `mypy` are all clean on the changed files.
