### PR TITLE
Add missing cp932 compat name (CP932)

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -23,6 +23,12 @@ Changelog
   encoding-name table in :doc:`usage`.
   (`António Afonso <https://github.com/aadsm>`_ via Claude,
   `#374 <https://github.com/chardet/chardet/pull/374>`_)
+- Fixed ``compat_names`` (the default) leaking the internal ``cp932`` codec
+  name.  ``detect()`` now returns ``CP932`` instead of ``cp932``, matching
+  its Japanese siblings (``shift_jis_2004`` → ``SHIFT_JIS``) and the value
+  chardet 5.x/6.x returned.
+  (`uttam12331 <https://github.com/uttam12331>`_,
+  `#375 <https://github.com/chardet/chardet/pull/375>`_)
 
 **Improvements:**
 

--- a/src/chardet/output_names.py
+++ b/src/chardet/output_names.py
@@ -52,6 +52,7 @@ _COMPAT_NAMES: dict[str, str] = {
     "cp855": "IBM855",
     "cp866": "IBM866",
     "cp874": "CP874",
+    "cp932": "CP932",
     "cp949": "CP949",
     "euc_jis_2004": "EUC-JP",
     "euc_kr": "EUC-KR",

--- a/tests/test_output_names.py
+++ b/tests/test_output_names.py
@@ -66,6 +66,16 @@ def test_compat_names_covers_windows_and_iso_families() -> None:
     assert _COMPAT_NAMES["iso8859-13"] == "ISO-8859-13"
 
 
+def test_compat_names_covers_cp932() -> None:
+    """Regression guard for the previously missing cp932 entry.
+
+    cp932 was absent from _COMPAT_NAMES, so the default ``compat_names=True``
+    path leaked the internal ``cp932`` codec name instead of the 5.x/6.x
+    display name ``CP932`` used by its siblings (e.g. shift_jis_2004).
+    """
+    assert _COMPAT_NAMES["cp932"] == "CP932"
+
+
 def test_every_preferred_superset_target_has_compat_name() -> None:
     """Every ``prefer_superset`` target must have a ``_COMPAT_NAMES`` entry.
 


### PR DESCRIPTION
`_COMPAT_NAMES` maps internal Python codec names to the display names chardet 5.x/6.x returned (the default `compat_names=True` behavior). Every Japanese sibling is mapped — `shift_jis_2004 → "SHIFT_JIS"`, `euc_jis_2004 → "EUC-JP"` — but `cp932` had no entry, so `apply_compat_names()` passes the raw internal codec name through unchanged:

```python
>>> chardet.detect("髙橋①②③ソフトウェア開発日本語のテキストです".encode("cp932"))
{'encoding': 'cp932', ...}     # leaks the internal codec name
```

chardet 5.x/6.x returned `'CP932'` here, so this is the same inconsistency #374 just fixed for the Windows/ISO families — `cp932` is one more missing `_COMPAT_NAMES` key.

`git log -S '"cp932"'` on the file shows the key was never present, so it is a pure omission, not a deliberate exclusion. The value is unambiguous:
- legacy chardet set `self._charset_name = "CP932"` (`jpcntx.py`),
- the codec's canonical spelling is uppercase, and
- it matches the sibling convention (`cp949 → "CP949"`).

Closed issue #280 ("Failed to detect CP932 encoded file") uses the same `髙` (U+9AD9) kanji and states the expected result is `"CP932"`; detection was fixed in #353, but the compat layer still emitted lowercase.

After the change:

```python
>>> chardet.detect("髙橋①②③ソフトウェア開発日本語のテキストです".encode("cp932"))
{'encoding': 'CP932', ...}
```

Added `test_compat_names_covers_cp932` (mirrors the `#374` regression guard); it fails on `main` and passes with the change. `tests/test_output_names.py` passes; `ruff check`/`ruff format --check` add no new findings. I'll add a `docs/changelog.rst` entry referencing this PR number.
