### PR TITLE
Fix multi-byte encodings being eliminated when input ends mid-character

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -46,7 +46,7 @@ Listed in execution order. Each stage's name matches its module in `chardet.pipe
 6. **Markup charset** — `<meta charset>`, `<?xml encoding>`, PEP 263 coding-declaration extraction. Includes **markup superset promotion**.
 7. **ASCII** — pure-7-bit fast path.
 8. **UTF-8 validation** — multi-byte structural check.
-9. **Byte-validity filtering** — drop candidates whose codec raises on `bytes.decode()`.
+9. **Byte-validity filtering** — drop candidates whose codec cannot decode the data. An incomplete multi-byte sequence at the very end is tolerated, since the input is usually a prefix of a larger whole.
 10. **CJK gating** — drop CJK candidates lacking multi-byte structure (pair ratio, high-byte count, byte coverage, lead-byte diversity).
 11. **Structural probing** — score multi-byte encoding fit (`pipeline/structural.py`).
 12. **Statistical scoring** — bigram cosine similarity against language-specific **BigramProfile**s.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -13,6 +13,23 @@ Changelog
 
 **Bug Fixes:**
 
+- Fixed multi-byte encodings being eliminated when the input ends in an
+  incomplete character.  Byte-validity filtering decoded with a one-shot
+  strict decode, which cannot tell a truncated tail from corrupt data, so a
+  single dangling lead byte dropped every CJK candidate and the result came
+  down to input-length parity — a 184-byte GBK sample detected as
+  ``GB18030``, the same sample minus one byte as ``Windows-1256``.  This was
+  also reachable on complete, well-formed files, because chardet slices its
+  own input at ``max_bytes`` and at ``_SCAN_LIMIT`` in
+  ``_validate_bytes()``: a valid 14 kB GBK page with an honest
+  ``<meta charset="gbk">`` lost its declaration, and with it ``text/html``
+  and 0.95 confidence, whenever byte 4096 happened to split a character.
+  Validity checks now decode incrementally with ``final=False``, deferring a
+  partial trailing character while still rejecting corruption anywhere
+  before it.
+  (`António Afonso <https://github.com/aadsm>`_ via Claude,
+  `#376 <https://github.com/chardet/chardet/pull/376>`_)
+
 - Fixed ``compat_names`` (the default) leaking internal Python codec names
   for seven encodings.  ``detect()`` now returns ``ISO-8859-2``,
   ``ISO-8859-6``, ``ISO-8859-13``, ``Windows-1250``, ``Windows-1256``,

--- a/docs/how-it-works.rst
+++ b/docs/how-it-works.rst
@@ -47,7 +47,10 @@ order:
 
 9. **Byte Validity Filtering** — Attempts to decode the data with each
    candidate encoding's Python codec. Any encoding that raises a decode
-   error is eliminated.
+   error is eliminated. An incomplete multi-byte sequence at the very end
+   of the data does not count as an error: detection input is usually a
+   prefix of a larger whole, so a partial trailing character means the
+   input was cut mid-character rather than that the encoding is wrong.
 
 10. **CJK Gating** — Eliminates CJK candidates that lack genuine
     multi-byte structure. Checks pair ratio, high-byte count, byte

--- a/src/chardet/_utils.py
+++ b/src/chardet/_utils.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import codecs
 import warnings
 
 #: Default maximum number of bytes to examine during detection.
@@ -22,6 +23,38 @@ def _warn_deprecated_chunk_size(chunk_size: int, stacklevel: int = 3) -> None:
             DeprecationWarning,
             stacklevel=stacklevel,
         )
+
+
+def decodes_without_error(data: bytes, encoding: str) -> bool:
+    """Return ``True`` if *data* decodes cleanly under *encoding*.
+
+    Equivalent to ``data.decode(encoding, errors="strict")`` except that an
+    incomplete multi-byte sequence at the *end* of *data* is accepted instead of
+    raising.
+
+    Detection input is nearly always a prefix of a larger whole.  Callers pass
+    the first N bytes of a file, and chardet slices further on its own.
+    For a two-byte encoding any of those cuts lands mid-character roughly half
+    the time.
+
+    A one-shot strict decode cannot tell a truncated tail from corrupt data: it
+    raises either way, so the candidate is discarded and every CJK encoding can
+    disappear from the candidate set over a single dangling lead byte. An
+    incremental decoder with ``final=False`` defers the partial tail instead,
+    while still raising on genuine corruption anywhere before it.
+
+    :param data: The raw byte data to test.
+    :param encoding: Name of the codec to test *data* against.
+    :returns: ``True`` if *data* decodes without error, ``False`` otherwise.
+    """
+    try:
+        codecs.getincrementaldecoder(encoding)().decode(data, final=False)
+    except (UnicodeError, LookupError):
+        # UnicodeError rather than UnicodeDecodeError: the utf-16/utf-32
+        # incremental decoders raise a bare UnicodeError when the stream does
+        # not start with a BOM.
+        return False
+    return True
 
 
 def _validate_max_bytes(max_bytes: int) -> None:

--- a/src/chardet/pipeline/markup.py
+++ b/src/chardet/pipeline/markup.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import re
 
+from chardet._utils import decodes_without_error
 from chardet.pipeline import DETERMINISTIC_CONFIDENCE, DetectionResult, PipelineContext
 from chardet.pipeline.structural import compute_structural_score
 from chardet.registry import REGISTRY, lookup_encoding
@@ -125,9 +126,7 @@ def promote_markup_superset(
         return markup_result
     superset_info = REGISTRY[superset_name]
     # Validate: superset must be able to decode the data
-    try:
-        data.decode(superset_name, errors="strict")
-    except (UnicodeDecodeError, LookupError):
+    if not decodes_without_error(data, superset_name):
         return markup_result
     # Compare structural scores
     ctx = PipelineContext()
@@ -150,8 +149,4 @@ def _validate_bytes(data: bytes, encoding: str) -> bool:
     full 200 kB input just to verify a charset declaration found in the
     header.
     """
-    try:
-        data[:_SCAN_LIMIT].decode(encoding)
-    except (UnicodeDecodeError, LookupError, ValueError):
-        return False
-    return True
+    return decodes_without_error(data[:_SCAN_LIMIT], encoding)

--- a/src/chardet/pipeline/validity.py
+++ b/src/chardet/pipeline/validity.py
@@ -5,6 +5,7 @@ this module is compiled with mypyc, which does not support PEP 563 string
 annotations.
 """
 
+from chardet._utils import decodes_without_error
 from chardet.registry import EncodingInfo
 
 
@@ -20,11 +21,4 @@ def filter_by_validity(
     if not data:
         return candidates
 
-    valid = []
-    for enc in candidates:
-        try:
-            data.decode(enc.name, errors="strict")
-            valid.append(enc)
-        except (UnicodeDecodeError, LookupError):
-            continue
-    return tuple(valid)
+    return tuple(enc for enc in candidates if decodes_without_error(data, enc.name))

--- a/tests/test_markup.py
+++ b/tests/test_markup.py
@@ -79,8 +79,17 @@ def test_unknown_encoding_returns_none():
 
 
 def test_lying_charset_declaration_rejected():
-    # Declares shift_jis but contains invalid bytes for that encoding
-    data = b'<meta charset="shift_jis">' + "日本語テスト".encode()
+    # Declares shift_jis but contains invalid bytes for that encoding.
+    #
+    # The body must be undecodable before its final character: validity
+    # tolerates an incomplete trailing one, so a body whose only defect is a
+    # dangling lead byte would pass.  It must also be undecodable under
+    # shift_jis_2004 -- what "shift_jis" resolves to, with a wider repertoire
+    # than shift_jis itself.
+    data = (
+        b'<meta charset="shift_jis">'
+        + "これは文字コード判定のテストに用いる日本語の文章です。".encode()
+    )
     result = detect_markup_charset(data)
     assert result is None
 

--- a/tests/test_truncated_input.py
+++ b/tests/test_truncated_input.py
@@ -1,0 +1,108 @@
+# tests/test_truncated_input.py
+"""Detection must be stable when the input is a prefix of a larger whole.
+
+Callers routinely detect on a slice -- an editor reads the first 4 kB or 64 kB
+of a file and hands over the buffer -- and chardet slices further on its own,
+``data[:max_bytes]`` in the orchestrator and ``data[:_SCAN_LIMIT]`` in
+:func:`chardet.pipeline.markup._validate_bytes`.  For a two-byte encoding any
+of those cuts lands mid-character about half the time.
+
+Validity filtering used to decode with a one-shot strict decode, which cannot
+tell a truncated tail from corrupt data, so a single dangling lead byte dropped
+every CJK candidate and the answer came down to input-length parity.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import chardet
+from chardet._utils import DEFAULT_MAX_BYTES, decodes_without_error
+from chardet.enums import EncodingEra
+from chardet.pipeline.markup import _validate_bytes, detect_markup_charset
+from chardet.pipeline.validity import filter_by_validity
+from chardet.registry import get_candidates
+
+_ZH = "這是一個用於測試編碼偵測的中文句子，內容足夠長以便統計模型能夠正確判斷。"
+_JA = "これは文字コード判定のテストに用いる日本語の文章です。統計モデルが正しく判定できる長さにしています。"
+_KO = "이것은 문자 인코딩 감지를 테스트하기 위한 한국어 문장입니다. 통계 모델이 올바르게 판단할 수 있을 만큼 충분히 깁니다."
+
+# One entry per multi-byte family.  The expected value is a prefix match rather
+# than an exact name because a superset (gb18030 for gbk, cp932 for shift_jis,
+# cp949 for euc_kr) is an equally correct answer -- the point is that the family
+# survives, not which member wins.
+_MULTIBYTE_SAMPLES = [
+    ("gbk", (_ZH * 4).encode("gbk"), ("gb",)),
+    ("big5", (_ZH * 4).encode("big5"), ("big5",)),
+    ("shift_jis", (_JA * 4).encode("shift_jis"), ("shift_jis", "cp932")),
+    ("euc_jp", (_JA * 4).encode("euc_jp"), ("euc-jp", "euc_jp")),
+    ("euc_kr", (_KO * 4).encode("euc_kr"), ("euc-kr", "euc_kr", "cp949")),
+    ("utf-8", (_ZH * 4).encode(), ("utf-8",)),
+]
+
+# Four consecutive prefixes cover every byte-boundary offset for encodings up to
+# four bytes per character, so at least one prefix per run cuts mid-character.
+_PREFIX_OFFSETS = (0, 1, 2, 3, 4)
+
+
+@pytest.mark.parametrize(("name", "data", "expected"), _MULTIBYTE_SAMPLES)
+def test_detection_stable_across_truncated_prefixes(
+    name: str, data: bytes, expected: tuple[str, ...]
+) -> None:
+    for offset in _PREFIX_OFFSETS:
+        prefix = data[: len(data) - offset]
+        result = chardet.detect(prefix, encoding_era=EncodingEra.ALL)
+        encoding = (result["encoding"] or "").lower()
+        assert encoding.startswith(expected), (
+            f"{name} minus {offset} byte(s) detected as {result['encoding']}"
+        )
+
+
+def test_truncated_tail_keeps_encoding_as_candidate():
+    data = (_ZH * 4).encode("gbk")[:-1]
+    candidates = tuple(
+        e for e in get_candidates(EncodingEra.ALL) if e.name.startswith("gb")
+    )
+    assert candidates
+    assert filter_by_validity(data, candidates)
+
+
+def test_illegal_trail_byte_still_eliminates_encoding():
+    # 0xD6 is a valid gbk lead byte; 0x20 is not a valid trail byte.
+    assert not decodes_without_error(b"\xd5\xe2\xca\xc7\xd6\x20", "gbk")
+
+
+def test_unmapped_bytes_still_eliminate_encoding():
+    assert not decodes_without_error(b"\xd5\xe2\xca\xc7\xff\xff", "gbk")
+
+
+def test_corruption_before_a_truncated_tail_is_still_caught():
+    # Corrupt pair mid-buffer, then a dangling lead byte at the end.  Tolerating
+    # the tail must not tolerate the corruption ahead of it.
+    assert not decodes_without_error(b"\xd5\xe2\xff\xff\xd2\xbb\xd6", "gbk")
+
+
+def test_markup_declaration_survives_the_scan_limit_cut():
+    # A complete, well-formed page with an honest declaration.  _validate_bytes
+    # slices its own 4 kB head, and one byte of padding decides whether that cut
+    # lands mid-character -- which must not change the answer.
+    body = (_ZH * 200).encode("gbk")
+    for pad in (0, 1):
+        data = b'<meta charset="gbk">' + b" " * pad + body
+        assert _validate_bytes(data, "gbk")
+        result = detect_markup_charset(data)
+        assert result is not None, f"pad={pad} rejected an honest declaration"
+        assert result.mime_type == "text/html"
+
+
+def test_detection_survives_the_max_bytes_cut():
+    # Likewise for the orchestrator's own data[:max_bytes] slice, on a complete
+    # file larger than that limit.
+    body = _ZH.encode("gbk")
+    data = body * (DEFAULT_MAX_BYTES // len(body) + 200)
+    assert len(data) > DEFAULT_MAX_BYTES
+    for pad in (0, 1):
+        result = chardet.detect(b" " * pad + data, encoding_era=EncodingEra.ALL)
+        assert (result["encoding"] or "").lower().startswith("gb"), (
+            f"pad={pad} detected as {result['encoding']}"
+        )


### PR DESCRIPTION
Byte-validity filtering decodes with a one-shot strict decode, which cannot distinguish an incomplete trailing multi-byte sequence from corrupt data. A single dangling lead byte therefore eliminates every CJK candidate, and the result comes down to input-length parity:

    >>> data = ("這是一個用於測試編碼偵測的中文句子。" * 4).encode("gbk")
    >>> chardet.detect(data)["encoding"]
    'GB18030'
    >>> chardet.detect(data[:-1])["encoding"]
    'Windows-1256'

The GB family is dropped from the candidate list, not merely outranked. gbk, big5, shift_jis, euc_jp and euc_kr all flip to an unrelated single-byte encoding when one trailing byte is removed. UTF-8 is unaffected: its lead byte encodes the sequence length, and stage 8 handles it before validity filtering runs.

Callers passing a prefix hit this, but so do complete files, because chardet slices its own input at `data[:max_bytes]` in `orchestrator._run_pipeline_core` and at `data[:_SCAN_LIMIT]` in `markup._validate_bytes`. On a valid 14 kB GBK page with an honest `<meta charset="gbk">`, one byte of padding decides whether byte 4096 splits a character:

    pad=0  ->  GB18030 @ 0.950, text/html
    pad=1  ->  GB18030 @ 0.185, text/plain

The same shift moves the reported name between a codec and its superset (`EUC-KR` vs `CP949`, `SHIFT_JIS` vs `cp932`), since a failed markup validation also skips superset promotion. On a complete 288 kB GBK file the `max_bytes` cut changes the encoding itself: `GB18030` at one padding, `Windows-1256` at the other.

## Fix

Add `_utils.decodes_without_error`, which decodes with an incremental decoder and `final=False` so a partial trailing character is deferred rather than raised on, and use it at all three validity sites (`filter_by_validity`, `markup._validate_bytes`, `markup.promote_markup_superset`).

Corruption anywhere before the tail still raises:

| case | before | after |
| --- | --- | --- |
| complete GBK | accept | accept |
| truncated mid-character | reject | accept |
| illegal trail byte (`D6 20`) | reject | reject |
| unmapped bytes (`FF FF`) | reject | reject |
| corruption before a cut tail | reject | reject |

## Two things worth noticing

**The exception width narrowed.** The helper catches `(UnicodeError, LookupError)` — `UnicodeError` rather than `UnicodeDecodeError` because the utf-16/utf-32 incremental decoders raise a bare `UnicodeError` on a BOM-less stream. That is narrower than the `ValueError` `_validate_bytes` caught before, which 0af01d6d added as defence in depth against an embedded null in a charset declaration (#369). The real guard for that is `lookup_encoding()`, which rejects such names: dropping `ValueError` from it fails `test_lookup_encoding_embedded_null`, `test_null_byte_in_charset_name` and `test_detect_null_in_markup_charset`, while dropping it from the helper fails nothing. Catching it in the helper would only mask unrelated errors as a failed decode. Happy to restore the wider catch if you would rather keep it.

**An existing test's fixture changed.** `test_lying_charset_declaration_rejected` used `"日本語テスト".encode()` declared as `shift_jis`. Those 18 bytes are a run of legal shift_jis_2004 characters whose only defect is a dangling lead byte at the end, so the test was proving the lie solely via the tail — the signal this change stops treating as evidence. The replacement body fails mid-buffer under both shift_jis and shift_jis_2004. Note the check was always partial: `"こんにちは世界"` as UTF-8 decodes cleanly as shift_jis and passed before this change too.

## Tests and docs

New `tests/test_truncated_input.py` asserts detection is stable across five consecutive prefix lengths for each multi-byte family, covering every byte phase up to four bytes per character, plus the two self-inflicted cuts on complete files and the corruption cases above. It fails on main and passes here.

`CONTEXT.md` and `docs/how-it-works.rst` described the stage as eliminating any encoding whose codec raises, which is no longer accurate. Changelog entry added under 7.5.0.

Full suite: 9250 passed, 28 xfailed. Accuracy corpus unchanged from main (7523 passed, 28 xfailed). `ruff check` and `ruff format` clean.
