### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/benchmark-x86.yml
+++ b/.github/workflows/benchmark-x86.yml
@@ -10,6 +10,9 @@ name: Benchmark x86
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   benchmark-x86:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/chardet/chardet/security/code-scanning/5](https://github.com/chardet/chardet/security/code-scanning/5)

Add an explicit `permissions` block to this workflow so `GITHUB_TOKEN` is least-privileged.  
Best fix: define it at the workflow root (applies to all jobs unless overridden), with `contents: read` as the minimal required scope for checkout/read operations. This preserves behavior and satisfies CodeQL.

**File to change:** `.github/workflows/benchmark-x86.yml`  
**Region:** after the `on:` trigger section and before `jobs:`.  
**No imports/dependencies/methods** are needed; this is YAML configuration only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
