### PR TITLE
Demote niche Latin encodings on evidence margin, not on distinguishing-byte presence

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -90,6 +90,21 @@ Unreleased
   process at import.  Importing the shim is no longer an error under
   ``-W error::DeprecationWarning``.
   (`Dan Blanchard <https://github.com/dan-blanchard>`_ via Claude)
+- A mostly-ASCII Windows-1252 file whose only non-ASCII content is a
+  lone accented-letter pair (one ``Ö``/``ö``) no longer detects as
+  HP-Roman8.  The niche Latin demotion stood down whenever the data
+  contained any byte the candidate decodes differently from ISO-8859-1,
+  but presence is symmetric evidence: the same byte that handed
+  HP-Roman8 its sub-epsilon lead also vetoed the demotion meant to
+  correct it.  The veto now requires the distinguishing bytes to have
+  earned the winning model more confidence than the dead-heat epsilon.
+  The demotion's replacement is likewise no longer picked by sub-epsilon
+  noise: among common Latin candidates tied with the best-placed of them,
+  era prevalence chooses (Windows-1252 over ISO-8859-1), while a
+  candidate leading its rivals by a real margin is still promoted on
+  confidence.
+  (`António Afonso <https://github.com/aadsm>`_ via Claude,
+  `#383 <https://github.com/chardet/chardet/pull/383>`_)
 
 **Build:**
 

--- a/src/chardet/pipeline/postprocess.py
+++ b/src/chardet/pipeline/postprocess.py
@@ -21,7 +21,15 @@ from chardet._utils import (
     decodes_completely,
     decodes_without_error,
 )
-from chardet.models import ART_LANGUAGE, RARE_LANGUAGES, get_enc_index
+from chardet.models import (
+    _ASCII_WHITESPACE_TABLE,
+    ART_LANGUAGE,
+    RARE_LANGUAGES,
+    BigramProfile,
+    get_enc_index,
+    get_idf_weights,
+    score_with_profile,
+)
 from chardet.output_names import _COMPAT_NAMES
 from chardet.pipeline import DetectionResult
 from chardet.pipeline.confusion import (
@@ -215,18 +223,29 @@ _DEMOTION_DELETE: dict[str, bytes] = {
 _KOI8_T_DELETE: bytes = bytes(_KOI8_T_DISTINGUISHING)
 
 
-def _should_demote(encoding: str, data: bytes) -> bool:
-    """Return True if encoding is a demotion candidate with no distinguishing bytes.
+def _should_demote(encoding: str, data: bytes, language: "str | None") -> bool:
+    """Return True if encoding is a demotion candidate with no real byte evidence.
 
     Checks whether any byte in *data* falls in the set of byte values that
     decode differently under the given encoding vs iso-8859-1.  If none do,
     the data is equally valid under both encodings and there is no
     byte-level evidence for preferring the candidate encoding.
+
+    Presence alone is not enough to stand the demotion down, though: a
+    mostly-ASCII Latin-1 file whose only non-ASCII bytes are one 0xD6/0xF6
+    pair carries a "distinguishing" byte (0xD6 is a lowercase letter under
+    hp-roman8, uppercase O-umlaut under Latin-1) while the winning model
+    earned less confidence from all its high-byte bigrams than the
+    dead-heat epsilon.  Such a win is statistical noise wearing a
+    distinguishing byte as a costume, so the demotion also fires when the
+    high-byte evidence contribution is at or under the noise floor.
     """
     delete = _DEMOTION_DELETE.get(encoding)
     if delete is None:
         return False
-    return len(data.translate(None, delete)) == len(data)
+    if len(data.translate(None, delete)) == len(data):
+        return True
+    return _high_byte_evidence_margin(data, encoding, language) <= _DEAD_HEAT_EPSILON
 
 
 def _demote_niche_latin(
@@ -241,6 +260,15 @@ def _demote_niche_latin(
     encoding, promote the first common Western Latin candidate to the top and
     push the demoted encoding to last.
 
+    The replacement is the most prevalent common Latin candidate among
+    those tied with the best-scoring one (within :data:`_DEAD_HEAT_EPSILON`
+    of the highest-confidence common Latin candidate): inside that band
+    the confidence order is noise — the very premise of the demotion — so
+    era prevalence picks between e.g. iso-8859-1 and windows-1252 rather
+    than a sub-epsilon score difference.  A candidate trailing the best
+    common Latin by more than the epsilon lost to it on real evidence and
+    stays put.
+
     The demoted entries take the confidence of the candidate they now sit
     behind.  Rank position alone does not survive the trip out to callers:
     ``detect_all`` re-sorts by confidence, and a stable sort hands an entry
@@ -252,30 +280,33 @@ def _demote_niche_latin(
     if (
         len(results) > 1
         and results[0].encoding is not None
-        and _should_demote(results[0].encoding, data)
+        and _should_demote(results[0].encoding, data, results[0].language)
     ):
         demoted_encoding = results[0].encoding
         top_conf = results[0].confidence
-        for r in results[1:]:
-            if r.encoding in _COMMON_LATIN_ENCODINGS:
-                promoted = DetectionResult(
-                    r.encoding, top_conf, r.language, r.mime_type
+        candidates = [r for r in results[1:] if r.encoding in _COMMON_LATIN_ENCODINGS]
+        if candidates:
+            lead_conf = candidates[0].confidence
+            in_band = [
+                r for r in candidates if lead_conf - r.confidence <= _DEAD_HEAT_EPSILON
+            ]
+            r = min(in_band, key=lambda x: _era_rank(x.encoding or ""))
+            promoted = DetectionResult(r.encoding, top_conf, r.language, r.mime_type)
+            others = [
+                x for x in results if x.encoding != demoted_encoding and x is not r
+            ]
+            tail_conf = others[-1].confidence if others else top_conf
+            demoted_entries = [
+                DetectionResult(
+                    x.encoding,
+                    min(x.confidence, tail_conf),
+                    x.language,
+                    x.mime_type,
                 )
-                others = [
-                    x for x in results if x.encoding != demoted_encoding and x is not r
-                ]
-                tail_conf = others[-1].confidence if others else top_conf
-                demoted_entries = [
-                    DetectionResult(
-                        x.encoding,
-                        min(x.confidence, tail_conf),
-                        x.language,
-                        x.mime_type,
-                    )
-                    for x in results
-                    if x.encoding == demoted_encoding
-                ]
-                return [promoted, *others, *demoted_entries]
+                for x in results
+                if x.encoding == demoted_encoding
+            ]
+            return [promoted, *others, *demoted_entries]
     return results
 
 
@@ -380,6 +411,58 @@ def _has_high_byte_evidence(data: bytes, encoding: str, language: "str | None") 
             if table[idx]:
                 return True
     return False
+
+
+def _high_byte_evidence_margin(
+    data: bytes, encoding: str, language: "str | None"
+) -> float:
+    """Return the confidence *encoding*'s winning model earned from high-byte bigrams.
+
+    Measured in confidence units: the winning variant's cosine terms
+    restricted to bigrams with a byte >= 0x80, over the same scoring window
+    and with the same repeated-whitespace skip the statistical score used
+    (computed as a focused-profile score rescaled from the focused norm to
+    the full window's norm).  Used by the niche-Latin demotion, where
+    presence alone must not veto: a lone accented letter can put one
+    weight-1 bigram in some variant's table and hand the candidate a lead
+    worth less than the dead-heat epsilon itself.  Only the variant that
+    actually won (*language*) counts.  Only called on niche-Latin tops, so
+    the Python-level scan of the (capped) data is off the hot path.
+    """
+    variants = get_enc_index().get(encoding)
+    if not variants:
+        return 0.0
+    window = data[:_EVIDENCE_SCAN_MAX_BYTES]
+    full = BigramProfile(window)
+    if full.input_norm == 0.0:
+        return 0.0
+    idf = get_idf_weights()
+    freq: dict[int, int] = {}
+    prev = window[0]
+    for i in range(1, len(window)):
+        b = window[i]
+        if (prev >= 0x80 or b >= 0x80) and not (
+            prev == b and _ASCII_WHITESPACE_TABLE[b]
+        ):
+            idx = (prev << 8) | b
+            freq[idx] = freq.get(idx, 0) + idf[idx]
+        prev = b
+    if not freq:
+        return 0.0
+    focused = BigramProfile.from_weighted_freq(freq)
+    # score_with_profile normalizes by the focused profile's norm; rescale
+    # to the full window's norm so the result is the contribution these
+    # bigrams make to the candidate's actual confidence.
+    rescale = focused.input_norm / full.input_norm
+    best = 0.0
+    for lang, model, model_key in variants:
+        if language is not None and lang != language:
+            continue
+        s = score_with_profile(focused, model, model_key)
+        if s > 0.0:
+            margin = s * rescale
+            best = max(best, margin)
+    return best
 
 
 def _prefer_prevalent_on_dead_heat(

--- a/tests/test_postprocess.py
+++ b/tests/test_postprocess.py
@@ -5,10 +5,12 @@ from collections.abc import Callable
 
 import pytest
 
+from chardet import detect
 from chardet.pipeline import DetectionResult, postprocess
 from chardet.pipeline.confusion import CONFUSION_FLOOR_RATIO, STRICT_TIER_MAX_CONF
 from chardet.pipeline.postprocess import (
     _demote_niche_latin,
+    _high_byte_evidence_margin,
     _promote_koi8t,
     forced_encodings,
     postprocess_results,
@@ -28,16 +30,43 @@ def test_demote_niche_latin():
     assert demoted[0].encoding == "cp1252"
 
 
-def test_demote_niche_latin_no_demote_when_distinguishing():
-    """iso-8859-10 should NOT be demoted when distinguishing bytes are present."""
+def test_demote_niche_latin_no_demote_when_evidence():
+    """iso-8859-10 stays when its distinguishing bytes carry real evidence.
+
+    The sample is Icelandic prose whose non-ASCII letters give the winning
+    model an evidence contribution far above the dead-heat epsilon —
+    presence of distinguishing bytes alone is no longer enough (see
+    test_demote_niche_latin_noise_level_evidence).
+    """
     results = [
         DetectionResult("iso8859-10", 0.90, None),
         DetectionResult("cp1252", 0.85, None),
     ]
-    # 0xA1 differs between iso-8859-10 and iso-8859-1
-    data = bytes([0xA1, 0xE9, 0xF6])
+    data = (
+        "Ąsta Þetta er íslenskur texti með mörgum séríslenskum "
+        "stöfum, æði þægilegt að lesa. "
+    ).encode("iso-8859-10") * 3
     demoted = _demote_niche_latin(data, results)
     assert demoted[0].encoding == "iso8859-10"
+
+
+def test_demote_niche_latin_noise_level_evidence():
+    """A distinguishing byte whose contribution is noise does not veto.
+
+    A mostly-ASCII Windows-1252 file whose only non-ASCII bytes are one
+    0xD6/0xF6 pair carries 0xD6 — in hp-roman8's distinguishing set — while
+    the winning model's whole high-byte contribution is under the dead-heat
+    epsilon.  The demotion must fire: the "real HP-Roman8 text contains
+    these bytes" premise assumes evidence, not a costume.
+    """
+    body = b"plain ascii text that goes on and on, filling space. " * 40
+    data = body + b"St\xd6rung? s\xf6mething. " + body
+    results = [
+        DetectionResult("hp-roman8", 0.39, "en"),
+        DetectionResult("cp1252", 0.39, "en"),
+    ]
+    demoted = _demote_niche_latin(data, results)
+    assert demoted[0].encoding == "cp1252"
 
 
 def test_promote_koi8t_with_tajik_bytes():
@@ -76,6 +105,63 @@ def test_promote_koi8t_returns_early_when_koi8t_absent():
     assert returned[0].encoding == "koi8-r"
 
 
+def test_demote_niche_latin_swap_prefers_prevalent_in_dead_heat():
+    """Era prevalence picks the swap target among tied common Latin candidates.
+
+    Inside the dead-heat band the confidence order between iso-8859-1 and
+    windows-1252 is noise (the demotion's own premise), so the replacement
+    must not depend on it: windows-1252 (era rank 1) wins over iso-8859-1
+    (era rank 2) even though iso-8859-1 ranks higher.
+    """
+    results = [
+        DetectionResult("hp-roman8", 0.39, "en"),
+        DetectionResult("cp437", 0.389995, "en"),
+        DetectionResult("iso8859-1", 0.38999, "en"),
+        DetectionResult("cp1252", 0.38998, "en"),
+    ]
+    data = bytes([0xE9])  # no hp-roman8-distinguishing byte -> demote
+    demoted = _demote_niche_latin(data, results)
+    assert demoted[0].encoding == "cp1252"
+    assert demoted[-1].encoding == "hp-roman8"
+
+
+def test_demote_niche_latin_swap_confidence_wins_outside_band():
+    """A real margin between the common Latin rivals still decides.
+
+    windows-1252 trails the best common Latin candidate (iso-8859-1) by
+    0.04 — far outside the band — so it lost on real evidence and
+    prevalence must not resurrect it.
+    """
+    results = [
+        DetectionResult("hp-roman8", 0.90, "en"),
+        DetectionResult("iso8859-1", 0.89, "en"),
+        DetectionResult("cp1252", 0.85, "en"),
+    ]
+    data = bytes([0xE9])  # no hp-roman8-distinguishing byte -> demote
+    demoted = _demote_niche_latin(data, results)
+    assert demoted[0].encoding == "iso8859-1"
+    assert demoted[-1].encoding == "hp-roman8"
+
+
+def test_demote_niche_latin_swap_band_anchors_on_best_common_latin():
+    """The tie band is anchored at the best common Latin, not the demoted top.
+
+    Both commons sit far below the demoted top (0.05, outside its band)
+    but only 5e-6 apart from each other — separable from the top, not
+    from each other.  Whether two rivals are separable is a fact about
+    their own gap, so era prevalence must still pick windows-1252.
+    """
+    results = [
+        DetectionResult("hp-roman8", 0.90, "en"),
+        DetectionResult("iso8859-1", 0.85, "en"),
+        DetectionResult("cp1252", 0.849995, "en"),
+    ]
+    data = bytes([0xE9])  # no hp-roman8-distinguishing byte -> demote
+    demoted = _demote_niche_latin(data, results)
+    assert demoted[0].encoding == "cp1252"
+    assert demoted[-1].encoding == "hp-roman8"
+
+
 def test_demote_niche_latin_iso_8859_14():
     """iso-8859-14 at top should be demoted when no distinguishing bytes."""
     results = [
@@ -98,6 +184,39 @@ def test_demote_niche_latin_windows_1254():
     assert demoted[0].encoding == "cp1252"
 
 
+def test_high_byte_evidence_margin_degenerate_inputs():
+    """The margin helper returns 0.0 when there is nothing to measure.
+
+    Three early-outs, none reachable through ``_should_demote`` on real
+    rankings: an encoding with no statistical models, a window too short
+    to contain a bigram, and a window whose bigrams are all ASCII.
+    """
+    assert _high_byte_evidence_margin(b"St\xd6rung", "ascii", "en") == 0.0
+    assert _high_byte_evidence_margin(b"\xd6", "hp-roman8", "en") == 0.0
+    assert _high_byte_evidence_margin(b"plain ascii text", "hp-roman8", "en") == 0.0
+
+
+def test_demote_niche_latin_end_to_end_lone_umlaut_pair():
+    """The full pipeline resolves the costume case to Windows-1252.
+
+    The reproduction from the report that motivated the evidence margin:
+    a mostly-ASCII file whose only non-ASCII bytes are one 0xD6/0xF6
+    pair.  The tests above hand ``_demote_niche_latin`` a ranking; this
+    one pins ``detect()`` itself, so a change anywhere upstream of the
+    demotion (scoring, dead-heat priors, chain order) that breaks the
+    outcome is caught.  The prevalence swap is pinned separately by the
+    swap unit tests: on this input windows-1252 already leads the other
+    common Latin candidates inside the tie band.
+    """
+    sentence = (
+        b"This is a mostly ASCII file with plain sentences that go on "
+        b"and on, describing nothing in particular, just filling space "
+        b"the way source files and configuration files usually do. "
+    )
+    data = sentence * 6 + b"St\xd6rung? s\xf6mething. " + sentence * 6
+    assert detect(data)["encoding"] == "Windows-1252"
+
+
 def test_demote_niche_latin_survives_a_confidence_resort():
     """The demotion must outlive a re-sort, not just reorder the list.
 
@@ -115,7 +234,7 @@ def test_demote_niche_latin_survives_a_confidence_resort():
     ]
     data = bytes([0xC0, 0xC1, 0xC2])
     demoted = _demote_niche_latin(data, results)
-    assert demoted[0].encoding == "iso8859-1"
+    assert demoted[0].encoding == "cp1252"  # most prevalent of the tied commons
     assert demoted[-1].encoding == "iso8859-14"
     confidences = [r.confidence for r in demoted]
     assert confidences == sorted(confidences, reverse=True)


### PR DESCRIPTION
I ran into this while running detection over source code files, which are mostly ASCII (the code itself) with sporadic non-ASCII text in comments/strings.

## Problem

A mostly-ASCII Windows-1252 file whose only non-ASCII content is a single `0xD6`/`0xF6` pair detects as **hp-roman8** instead of cp1252.

Reproduction:

```python
sentence = (
    b"This is a mostly ASCII file with plain sentences that go on and on, "
    b"describing nothing in particular, just filling space the way source "
    b"files and configuration files usually do. "
)
data = sentence * 6 + b"St\xd6rung? s\xf6mething. " + sentence * 6
chardet.detect(data)  # {'encoding': 'hp-roman8', ...}; expected Windows-1252
```

## Root cause

This is exactly the class of problem `_demote_niche_latin` exists to fix: an ASCII-dominated file where a niche Latin encoding reaches the top on statistically meaningless margins, and the demotion steps in to hand the win to the prevalent sibling. However, in this case `_should_demote` vetoes the demotion as soon as the data contains any byte from the candidate's *distinguishing set*, on the premise that "real HP-Roman8 text contains these bytes". But they can exist in both: `0xD6` is `Ö` in cp1252 and `ø` in hp-roman8, so the byte's existence says nothing about which reading is right. It only says the two candidates *disagree* here.

hp-roman8 gets a lead here because its model scores the `0xD6`/`0xF6` pair higher than cp1252 does, but not in a statistically significant way: its lead is 4.9e-6, far under the `_DEAD_HEAT_EPSILON` (1e-4) threshold. Since `0xD6` is a distinguishing byte, hp-roman8 doesn't get demoted, when in reality a sub-epsilon difference shouldn't be considered evidence that hp-roman8 is indeed the right choice.

## Fix

### When to demote

Replace the presence test with an evidence test. New helper `_high_byte_evidence_margin(data, encoding, language)` computes the confidence the winning variant actually earned from high-byte bigrams: its cosine terms restricted to bigrams with a byte >= 0x80, over the same 16 KB scoring window and with the same repeated-whitespace skip statistical scoring uses, rescaled from the focused norm to the full window's norm so the result is in confidence units.

`_should_demote` becomes:

- no distinguishing byte present: demote (unchanged);
- otherwise demote iff the margin is at or below `_DEAD_HEAT_EPSILON`. The distinguishing bytes must carry more than dead-heat-level evidence to save the candidate.

Measured margins: the misdetections earn between 0 and 3.5e-5 from their distinguishing bytes, well under the 1e-4 epsilon, while genuine iso-8859-10 Icelandic prose earns 0.15, three orders of magnitude above it. The gate sits in a wide gap, not on a knife-edge.

The scan is pure Python but off the hot path: it only runs when the top-ranked result is one of the four niche-Latin candidates.

### What to promote

`_demote_niche_latin` used to promote the first common Latin candidate in confidence order. When the top candidates are within `_DEAD_HEAT_EPSILON` of one another, that order is effectively arbitrary. The fix picks by era prevalence instead; a candidate trailing the best common Latin by more than the epsilon lost to it on real evidence and stays put.

## What didn't work

I tried the same gate (has more than epsilon worth of evidence) in `_prefer_prevalent_on_dead_heat` (the era-prevalence one) instead of using `_has_high_byte_evidence`, but it regressed six DOS-era files of the accuracy corpus. Their legitimate winners earn high-byte margins of 2.9e-5 to 9.5e-5, any threshold low enough to spare the legitimate cp437/cp850 wins also spares hp-roman8; any threshold high enough to catch hp-roman8 also flags the legitimate wins as evidence-free, letting the prior overturn them toward more "prevalent" encodings. The two populations overlap; no cutoff exists here.

## Test changes

- `test_demote_niche_latin_no_demote_when_distinguishing` is renamed to `test_demote_niche_latin_no_demote_when_evidence` (distinguishing-byte presence is no longer the guard) and needed a new sample: its old input scored a margin of exactly 0.0, meaning under the new rule it *should* demote, since the old bytes were shared with ISO-8859-1 in the winning model's view. The replacement is Icelandic prose with a leading `Ą` (pure Icelandic contains no iso-8859-10-distinguishing bytes; its letters coincide with Latin-1's code points).
- New `test_demote_niche_latin_noise_level_evidence` pins the new gate at the `_demote_niche_latin` level: a distinguishing byte whose evidence contribution is under the epsilon no longer saves the candidate.
- New `test_demote_niche_latin_swap_prefers_prevalent_in_dead_heat`, `test_demote_niche_latin_swap_confidence_wins_outside_band`, and `test_demote_niche_latin_swap_band_anchors_on_best_common_latin` pin the three sides of the swap rule: prevalence decides between tied candidates, a real margin decides between separated ones.
- `test_demote_niche_latin_survives_a_confidence_resort`'s fixture ties iso-8859-1 and windows-1252 exactly, so its expected winner updates to windows-1252 since it's more prevalent; its resort-survival assertions are unchanged.
- New `test_high_byte_evidence_margin_degenerate_inputs` covers the helper's three early-outs (no models for the encoding, window too short for a bigram, no high-byte bigrams), which real rankings can't reach.


**Note for review**: the end-to-end test (`test_demote_niche_latin_end_to_end_lone_umlaut_pair`) lives in `test_postprocess.py` next to the demotion unit tests. If you'd rather have it in `test_github_issues.py` keyed to this PR's number, I'm happy to move it.
