### PR TITLE
Add -m/--mime-type flag to chardetect CLI

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,6 +11,13 @@ Changelog
 Unreleased
 ----------
 
+**Features:**
+
+- Added ``-m``/``--mime-type`` flag to ``chardetect`` CLI — shows the
+  detected MIME type alongside the encoding, similar to ``file -i``
+  (`Dan Blanchard <https://github.com/dan-blanchard>`_ via Claude,
+  `#384 <https://github.com/chardet/chardet/issues/384>`_)
+
 **Accuracy:**
 
 - cp864 Arabic now trains on contextually shaped text in visual

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -383,6 +383,15 @@ chardet includes a ``chardetect`` command:
    chardetect --minimal -l somefile.txt
    # utf-8 en
 
+   # Include detected MIME type (similar to file -i)
+   chardetect -m somefile.txt somepic.png
+   # somefile.txt: utf-8 text/plain with confidence 0.99
+   # somepic.png: None image/png with confidence 1.0
+
+   # Minimal output with MIME type
+   chardetect --minimal -m somefile.txt
+   # utf-8 text/plain
+
    # Specific encoding era
    chardetect -e dos somefile.txt
    # somefile.txt: cp850 with confidence 0.10

--- a/src/chardet/cli.py
+++ b/src/chardet/cli.py
@@ -15,24 +15,24 @@ _ERA_NAMES = [e.name.lower() for e in EncodingEra if e.bit_count() == 1] + ["all
 
 
 def _print_result(
-    result: DetectionDict, label: str, *, minimal: bool, language: bool
+    result: DetectionDict, label: str, *, minimal: bool, language: bool, mime_type: bool
 ) -> None:
     """Print a detection result to stdout."""
+    desc = str(result["encoding"])
     if minimal:
         if language:
-            iso = result["language"] or "und"
-            print(f"{result['encoding']} {iso}")
-        else:
-            print(result["encoding"])
-    elif language:
-        iso = result["language"] or "und"
-        name = ISO_TO_LANGUAGE.get(iso, iso).title()
-        print(
-            f"{label}: {result['encoding']} {iso} ({name}) "
-            f"with confidence {result['confidence']}"
-        )
+            desc += f" {result['language'] or 'und'}"
+        if mime_type:
+            desc += f" {result['mime_type'] or 'application/octet-stream'}"
+        print(desc)
     else:
-        print(f"{label}: {result['encoding']} with confidence {result['confidence']}")
+        if language:
+            iso = result["language"] or "und"
+            name = ISO_TO_LANGUAGE.get(iso, iso).title()
+            desc += f" {iso} ({name})"
+        if mime_type:
+            desc += f" {result['mime_type'] or 'application/octet-stream'}"
+        print(f"{label}: {desc} with confidence {result['confidence']}")
 
 
 def main(argv: list[str] | None = None) -> None:
@@ -50,6 +50,12 @@ def main(argv: list[str] | None = None) -> None:
         "--language",
         action="store_true",
         help="Include detected language in output",
+    )
+    parser.add_argument(
+        "-m",
+        "--mime-type",
+        action="store_true",
+        help="Include detected MIME type in output",
     )
     parser.add_argument(
         "-e",
@@ -125,7 +131,11 @@ def main(argv: list[str] | None = None) -> None:
                 errors += 1
                 continue
             _print_result(
-                result, filepath, minimal=args.minimal, language=args.language
+                result,
+                filepath,
+                minimal=args.minimal,
+                language=args.language,
+                mime_type=args.mime_type,
             )
         if errors == len(args.files):
             sys.exit(1)
@@ -143,7 +153,13 @@ def main(argv: list[str] | None = None) -> None:
         except Exception as e:  # noqa: BLE001
             print(f"chardetect: stdin: detection failed: {e}", file=sys.stderr)
             sys.exit(1)
-        _print_result(result, "stdin", minimal=args.minimal, language=args.language)
+        _print_result(
+            result,
+            "stdin",
+            minimal=args.minimal,
+            language=args.language,
+            mime_type=args.mime_type,
+        )
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -300,6 +300,115 @@ def test_cli_without_language_flag_unchanged(
     assert "(" not in captured.out
 
 
+def test_cli_mime_type_flag(tmp_path: Path, capsys: pytest.CaptureFixture[str]):
+    """--mime-type should include the MIME type in output."""
+    f = tmp_path / "test.txt"
+    f.write_bytes(b"Hello world")
+    main(["--mime-type", str(f)])
+    captured = capsys.readouterr()
+    assert "text/plain" in captured.out
+    assert "with confidence" in captured.out
+
+
+def test_cli_mime_type_short_flag(tmp_path: Path, capsys: pytest.CaptureFixture[str]):
+    """-m should work as short form of --mime-type."""
+    f = tmp_path / "test.txt"
+    f.write_bytes(b"Hello world")
+    main(["-m", str(f)])
+    captured = capsys.readouterr()
+    assert "text/plain" in captured.out
+
+
+def test_cli_mime_type_binary_file(tmp_path: Path, capsys: pytest.CaptureFixture[str]):
+    """--mime-type on a PNG should report image/png from magic numbers."""
+    f = tmp_path / "test.png"
+    f.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 32)
+    main(["--mime-type", str(f)])
+    captured = capsys.readouterr()
+    assert "image/png" in captured.out
+
+
+def test_cli_mime_type_minimal(tmp_path: Path, capsys: pytest.CaptureFixture[str]):
+    """--mime-type + --minimal should print encoding and MIME type."""
+    f = tmp_path / "test.txt"
+    f.write_bytes(b"Hello world")
+    main(["--minimal", "--mime-type", str(f)])
+    captured = capsys.readouterr()
+    assert captured.out.strip() == "ascii text/plain"
+
+
+def test_cli_mime_type_minimal_language(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+):
+    """--minimal -l -m should print encoding, language code, and MIME type."""
+    f = tmp_path / "test.txt"
+    f.write_bytes("Héllo wörld café résumé naïve".encode())
+    main(["--minimal", "-l", "-m", str(f)])
+    captured = capsys.readouterr()
+    parts = captured.out.strip().split()
+    assert len(parts) == 3
+    assert parts[2] == "text/plain"
+
+
+def test_cli_mime_type_with_language(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+):
+    """-l -m should show language and MIME type before the confidence."""
+    f = tmp_path / "test.txt"
+    f.write_bytes("Héllo wörld café résumé naïve".encode())
+    main(["-l", "-m", str(f)])
+    captured = capsys.readouterr()
+    assert "(" in captured.out
+    assert "text/plain with confidence" in captured.out
+
+
+def test_cli_mime_type_stdin(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+):
+    """--mime-type on stdin should include MIME type in output."""
+    fake_stdin = io.TextIOWrapper(io.BytesIO(b"Hello world"))
+    monkeypatch.setattr(sys, "stdin", fake_stdin)
+    main(["--mime-type"])
+    captured = capsys.readouterr()
+    assert "text/plain" in captured.out
+    assert "with confidence" in captured.out
+
+
+def test_cli_mime_type_none_shows_octet_stream(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+):
+    """When mime_type is None, should display 'application/octet-stream'."""
+    f = tmp_path / "test.txt"
+    f.write_bytes(b"Hello world")
+    monkeypatch.setattr(
+        chardet,
+        "detect",
+        lambda *_a, **_kw: {
+            "encoding": "ascii",
+            "confidence": 1.0,
+            "language": None,
+            "mime_type": None,
+        },
+    )
+    main(["--minimal", "--mime-type", str(f)])
+    captured = capsys.readouterr()
+    assert captured.out.strip() == "ascii application/octet-stream"
+
+
+def test_cli_without_mime_type_flag_unchanged(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+):
+    """Without --mime-type, output should not contain the MIME type."""
+    f = tmp_path / "test.txt"
+    f.write_bytes(b"Hello world")
+    main([str(f)])
+    captured = capsys.readouterr()
+    assert "with confidence" in captured.out
+    assert "text/plain" not in captured.out
+
+
 def test_cli_include_encodings(tmp_path: Path, capsys: pytest.CaptureFixture[str]):
     f = tmp_path / "test.txt"
     f.write_bytes(b"Hello world")


### PR DESCRIPTION
Fixes #384

`detect()` has returned a `mime_type` field since 7.0, but the CLI had no way to show it. This adds a `-m`/`--mime-type` flag to `chardetect` that appends the detected MIME type to the output, similar to `file -i`:

```
$ chardetect -m somefile.txt somepic.png
somefile.txt: utf-8 text/plain with confidence 0.99
somepic.png: None image/png with confidence 1.0

$ chardetect --minimal -m somefile.txt
utf-8 text/plain

$ chardetect --minimal -l -m somefile.txt
utf-8 en text/plain
```

## Changes

- **`src/chardet/cli.py`** — `_print_result()` now builds the description incrementally (encoding, then optional language, then optional MIME type), so the new flag composes with `--minimal` and `-l` the same way the language flag does. Output without the flag is byte-identical to before. A `None` `mime_type` prints as `application/octet-stream`, matching `file`'s convention for unknowns. `--mime` also works as an unambiguous argparse prefix of `--mime-type`.
- **`tests/test_cli.py`** — nine new tests: long and short flags, a PNG detected via magic numbers (`image/png`), composition with `--minimal` and `-l`, stdin, the `None` fallback, and unchanged output without the flag.
- **`docs/usage.rst`** — CLI examples for the new flag.
- **`docs/changelog.rst`** — Features entry under Unreleased.

## Testing

- Full suite passes: 11,841 passed, 12 xfailed.
- `sphinx-build -W` docs build passes.
- `ruff check` and `ruff format --check` pass on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Py4AomcaGn2MC9CeHkruFJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Py4AomcaGn2MC9CeHkruFJ)_