### PR TITLE
Restore 100% test coverage and enforce it in CI

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -93,6 +93,16 @@ Unreleased
 
 **Build:**
 
+- Test coverage is back to 100% and CI now enforces it
+  (``fail_under = 100``).  The newly covered paths include the EBCDIC
+  plausibility checks in binary detection, charset declarations inside
+  EBCDIC-encoded markup, the packed-kernel scoring branch (pinned
+  bit-identical to the dense path), the confusion stage's decisive-vote
+  and strict-tier promotions, the classic-Mac and dead-heat rank
+  corrections, and the model-file fallback/truncation paths.  Two
+  provably unreachable defensive guards are excluded with explanatory
+  ``pragma: no cover`` comments instead of synthetic tests.
+  (`Dan Blanchard <https://github.com/dan-blanchard>`_ via Claude)
 - The ``models.bin``/``rowmax.bin``/``idf.bin`` formats now have a
   single owner, ``chardet.models._format``, called by both the trainer
   and the runtime loader; the row-maxima and IDF payloads regenerate

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -239,7 +239,7 @@ indent-style = "space"
 source = ["src/chardet"]
 
 [tool.coverage.report]
-fail_under = 95
+fail_under = 100
 show_missing = true
 exclude_lines = [
     "pragma: no cover",

--- a/src/chardet/models/_format.py
+++ b/src/chardet/models/_format.py
@@ -79,7 +79,12 @@ def _decompress_tables(
         if len(table) == 65536:
             models[names[len(models)]] = bytes(table)
             table.clear()
-        elif len(table) > 65536:
+        # Unreachable with CPython's zlib — decompress() pieces are capped at
+        # ``need``, and a flush() strand (the tail of one back-reference cut
+        # mid-copy, at most 258 bytes) only ever lands in a fresh table —
+        # but a decompressor that flushed more than asked must not corrupt
+        # the table split silently.
+        elif len(table) > 65536:  # pragma: no cover
             break  # oversized flush -> size mismatch below
     if len(models) == num_models:
         # Drain any leftover decompressed output so extra data is caught,

--- a/src/chardet/pipeline/confusion.py
+++ b/src/chardet/pipeline/confusion.py
@@ -599,7 +599,12 @@ def resolve_by_bigram_rescore(
             idx = (b1 << 8) | b2
             freq[idx] = freq.get(idx, 0) + idf[idx]
 
-    if not freq:
+    # Unreachable: the hit prefilter above already returned when no
+    # distinguishing byte occurs, and with len(data) >= 2 every hit byte
+    # belongs to at least one bigram, so both scan paths put a key in
+    # ``freq`` (a zero IDF weight still creates the key).  Kept so a future
+    # scan-path change cannot hand an empty profile to the scorer.
+    if not freq:  # pragma: no cover
         return None
 
     profile = BigramProfile.from_weighted_freq(freq)

--- a/tests/test_binary.py
+++ b/tests/test_binary.py
@@ -69,3 +69,39 @@ def test_just_above_threshold_is_binary():
     # 2 binary bytes in 100 = 2% > 0.01
     data = b"a" * 98 + b"\x01\x02"
     assert is_binary(data) is True
+
+
+def test_ebcdic_all_padding_is_not_binary():
+    """EBCDIC data that is nothing but space padding and tabs is text.
+
+    Every byte is either the EBCDIC space (0x40) or HT (0x05), so the
+    non-space denominator of the high-byte check is zero.
+    """
+    data = b"\x40" * 97 + b"\x05" * 3
+    assert is_binary(data) is False
+
+
+def test_ebcdic_whitespace_without_high_bytes_is_binary():
+    """EBCDIC-style whitespace in low-byte data is a binary indicator.
+
+    The NL bytes push the count over the threshold, but the data has almost
+    no high bytes, so it cannot be EBCDIC text.
+    """
+    data = b"ABC" * 30 + b"\x15" * 3 + b"\x40" * 10
+    assert is_binary(data) is True
+
+
+def test_ebcdic_high_bytes_without_word_separators_is_binary():
+    """High-byte data framed with EBCDIC newlines but no spaces is binary.
+
+    A binary payload can pass the high-byte check, but text separates
+    words: with almost no 0x40/0x05 separators it is classified binary.
+    """
+    data = b"\x81" * 97 + b"\x15" * 2 + b"\x05"
+    assert is_binary(data) is True
+
+
+def test_ebcdic_text_shape_is_not_binary():
+    """High-byte data with EBCDIC spaces and newlines is EBCDIC text."""
+    data = b"\x81" * 90 + b"\x40" * 8 + b"\x15" * 2
+    assert is_binary(data) is False

--- a/tests/test_confusion.py
+++ b/tests/test_confusion.py
@@ -569,3 +569,185 @@ def test_confusion_pair_winner_without_a_map_declines():
     assert (
         confusion_mod.confusion_pair_winner(_UKRAINIAN_KOI8U, "utf-8", "koi8-u") is None
     )
+
+
+#: One distinguishing occurrence of byte 0x48 between spaces, repeated.  In
+#: the cp1026/cp273 map 0x48 reads as punctuation under cp1026 and as a
+#: lowercase letter under cp273; with no letter neighbours the cp273 letter
+#: reading is word-shape-implausible, so each occurrence is a demotion event
+#: for cp1026 — three of them clear both decisiveness gates.
+_DECISIVE_CP1026 = b" \x48 " * 3
+
+#: The mirror image: byte 0x43 is a lowercase letter under cp1026 and
+#: punctuation under cp273, so the same shape demotes cp1026's rival and
+#: cp273 wins decisively.
+_DECISIVE_CP273 = b" \x43 " * 3
+
+
+def test_letter_case_table_skips_zero_char_decodes():
+    """A byte that decodes to no character at all gets no letter kind.
+
+    utf-7's ``+`` opens a base64 run and decodes to an empty string, which
+    ``unicodedata.category`` would reject; the table must skip it while
+    still classifying ordinary letters.
+    """
+    table = confusion_mod._letter_case_table("utf-7")
+    assert table[ord("+")] == 0
+    assert table[ord("A")] == 1
+    assert table[ord("a")] == 2
+
+
+def test_context_preference_isolated_letter_is_implausible():
+    """A letter with no letter neighbours reads as quoted punctuation."""
+    table = confusion_mod._letter_case_table("cp1252")
+    pref = confusion_mod._context_preference("Ll", ord(" "), ord(" "), table)
+    assert pref == confusion_mod._IMPLAUSIBLE_LETTER_PREFERENCE
+
+
+def test_context_preference_lowercase_before_uppercase_is_implausible():
+    """A lowercase letter immediately followed by an uppercase one is no word."""
+    table = confusion_mod._letter_case_table("cp1252")
+    pref = confusion_mod._context_preference("Ll", ord("x"), ord("A"), table)
+    assert pref == confusion_mod._IMPLAUSIBLE_LETTER_PREFERENCE
+
+
+def test_vote_demotion_counted_for_first_encoding():
+    """enc_a's votes earned against an implausible letter count as demotions."""
+    maps = confusion_mod.load_confusion_data()
+    diff, cats = maps[("cp1026", "cp273")]
+    winner, margin, demotion, events = confusion_mod._vote_with_margin(
+        _DECISIVE_CP1026, "cp1026", "cp273", diff, cats
+    )
+    assert winner == "cp1026"
+    assert margin > 0
+    assert demotion >= confusion_mod._DECISIVE_VOTE_MARGIN
+    assert events >= confusion_mod._DECISIVE_MIN_EVENTS
+
+
+def test_vote_demotion_counted_for_second_encoding():
+    """The mirror byte demotes cp1026 and credits cp273's side."""
+    maps = confusion_mod.load_confusion_data()
+    diff, cats = maps[("cp1026", "cp273")]
+    winner, margin, demotion, events = confusion_mod._vote_with_margin(
+        _DECISIVE_CP273, "cp1026", "cp273", diff, cats
+    )
+    assert winner == "cp273"
+    assert margin > 0
+    assert demotion >= confusion_mod._DECISIVE_VOTE_MARGIN
+    assert events >= confusion_mod._DECISIVE_MIN_EVENTS
+
+
+def test_vote_letter_beating_punctuation_is_not_evidence():
+    """A plausible letter reading over a punctuation reading earns no vote.
+
+    Punctuation legitimately borders letters, so with 0x48 flanked by
+    bytes both encodings read as letters, cp273's letter reading beats
+    cp1026's punctuation reading on naive preference alone — which must
+    not count, leaving the vote tied.
+    """
+    maps = confusion_mod.load_confusion_data()
+    diff, cats = maps[("cp1026", "cp273")]
+    winner, margin, demotion, events = confusion_mod._vote_with_margin(
+        b"\x81\x48\x82", "cp1026", "cp273", diff, cats
+    )
+    assert (winner, margin, demotion, events) == (None, 0, 0, 0)
+
+
+def test_confusion_pair_winner_decisive_vote_short_circuits():
+    """A decisive demotion vote answers without the bigram rescore."""
+    assert (
+        confusion_mod.confusion_pair_winner(_DECISIVE_CP273, "cp1026", "cp273")
+        == "cp273"
+    )
+
+
+@_needs_interpreted_build
+def test_confusion_pair_winner_cross_family_requires_corroboration():
+    """A cross-family pair needs the vote and the rescore to agree.
+
+    Cross-family maps carry 52+ distinguishing bytes.  With categories that
+    make the vote favour koi8-u — matching the rescore on Ukrainian koi8-u
+    text — the corroborated verdict stands; with the categories reversed
+    the vote and rescore disagree and no verdict is returned.
+    """
+    big_diff = frozenset(range(0x80, 0x80 + confusion_mod._CROSS_FAMILY_MIN_DIFFS))
+    assert len(big_diff) >= confusion_mod._CROSS_FAMILY_MIN_DIFFS
+    agree = {("koi8-r", "koi8-u"): (big_diff, dict.fromkeys(big_diff, ("So", "Ll")))}
+    disagree = {("koi8-r", "koi8-u"): (big_diff, dict.fromkeys(big_diff, ("Ll", "So")))}
+    with patch.object(confusion_mod, "load_confusion_data", return_value=agree):
+        assert (
+            confusion_mod.confusion_pair_winner(_UKRAINIAN_KOI8U, "koi8-r", "koi8-u")
+            == "koi8-u"
+        )
+    with patch.object(confusion_mod, "load_confusion_data", return_value=disagree):
+        assert (
+            confusion_mod.confusion_pair_winner(_UKRAINIAN_KOI8U, "koi8-r", "koi8-u")
+            is None
+        )
+
+
+def test_bigram_rescore_without_distinguishing_bigrams_declines():
+    """Data containing no distinguishing bytes yields no rescore verdict."""
+    assert (
+        confusion_mod.resolve_by_bigram_rescore(
+            b"hello world", "cp1252", "cp1250", frozenset({0xFF}), frozenset()
+        )
+        is None
+    )
+
+
+def test_resolve_confusion_groups_art_top_is_not_reviewed():
+    """An art-model win passes through: voting reasons about prose."""
+    results = [
+        DetectionResult("cp437", 0.30, confusion_mod._ART_LANGUAGE),
+        DetectionResult("cp850", 0.299, None),
+    ]
+    resolved = confusion_mod.resolve_confusion_groups(b"anything", results)
+    assert resolved == results
+
+
+def test_resolve_confusion_groups_in_band_decisive_vote():
+    """A decisive demotion vote promotes the in-band sibling."""
+    results = [
+        DetectionResult("cp1026", 0.10, None),
+        DetectionResult("cp273", 0.099, None),
+    ]
+    resolved = confusion_mod.resolve_confusion_groups(_DECISIVE_CP273, results)
+    assert resolved[0].encoding == "cp273"
+    assert resolved[0].confidence == 0.10
+
+
+def test_resolve_confusion_groups_strict_tier_decisive_vote():
+    """A decisive vote promotes an out-of-band candidate king-of-the-hill.
+
+    The top sits below the strict-tier confidence ceiling and the candidate
+    above the floor, so the tier opens even though the candidate is far
+    outside the band; the promotion carries the top confidence.
+    """
+    results = [
+        DetectionResult("cp1026", 0.10, None),
+        DetectionResult("ascii", 0.09, None),
+        DetectionResult("cp273", 0.06, None),
+    ]
+    resolved = confusion_mod.resolve_confusion_groups(_DECISIVE_CP273, results)
+    assert resolved[0].encoding == "cp273"
+    assert resolved[0].confidence == 0.10
+    assert [r.encoding for r in resolved[1:]] == ["cp1026", "ascii"]
+
+
+def test_resolve_confusion_groups_strict_tier_corroborated():
+    """Out of band, a non-decisive vote needs the rescore to agree.
+
+    On Ukrainian koi8-u text the koi8-r/koi8-u vote is won on letters
+    beating box-drawing symbols — no demotion events, so not decisive —
+    and the bigram rescore agrees, which is exactly the corroboration the
+    strict tier demands.
+    """
+    results = [
+        DetectionResult("koi8-r", 0.10, "ru"),
+        DetectionResult("ascii", 0.09, None),
+        DetectionResult("koi8-u", 0.06, "uk"),
+    ]
+    resolved = confusion_mod.resolve_confusion_groups(_UKRAINIAN_KOI8U, results)
+    assert resolved[0].encoding == "koi8-u"
+    assert resolved[0].confidence == 0.10

--- a/tests/test_escape.py
+++ b/tests/test_escape.py
@@ -423,3 +423,13 @@ def test_utf7_validator_is_linear_in_base64_blobs() -> None:
     start = time.perf_counter()
     _has_valid_utf7_sequences(blob, len(blob), len(blob))
     assert time.perf_counter() - start < 1.0
+
+
+def test_utf7_base64_run_outrunning_the_bound_is_skipped() -> None:
+    """A base64 run that reaches max_end while more follows is not judged.
+
+    The run cannot be validated whole, so it must be skipped rather than
+    judged on a truncated prefix (ADR-0006).
+    """
+    data = b"+" + b"AAAA" * 10
+    assert _has_valid_utf7_sequences(data, max_start=10, max_end=5) is False

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -5,6 +5,7 @@ from chardet.evaluation import (
     is_acceptable,
     is_correct,
     is_equivalent_detection,
+    is_exact_match,
     is_language_equivalent,
 )
 
@@ -208,3 +209,31 @@ def test_is_acceptable_rejects_differing_decodes():
     """Neither half accepts encodings that read this data differently."""
     data = "Привет мир".encode("cp1251")
     assert is_acceptable(data, "cp1251", "cp1252") is False
+
+
+def test_is_exact_match_none_expected():
+    """A binary expectation (None) matches only a binary detection."""
+    assert is_exact_match(None, None) is True
+    assert is_exact_match(None, "utf-8") is False
+
+
+def test_is_exact_match_none_detected():
+    """A failed detection never exactly matches a real expectation."""
+    assert is_exact_match("utf-8", None) is False
+
+
+def test_equivalent_detection_mixed_identical_and_equivalent_chars():
+    """Identical characters pass through while listed pairs are equivalent.
+
+    0xA4 is the currency sign in iso-8859-1 and the euro sign in
+    iso-8859-15 — a listed equivalence — while the ASCII prefix decodes
+    identically under both.
+    """
+    data = b"ab\xa4"
+    assert is_equivalent_detection(data, "iso-8859-1", "iso-8859-15") is True
+
+
+def test_equivalent_detection_length_mismatch_is_not_equivalent():
+    """Decodes of different lengths cannot be functionally identical."""
+    data = "é".encode()
+    assert is_equivalent_detection(data, "utf-8", "iso-8859-1") is False

--- a/tests/test_internal_utils.py
+++ b/tests/test_internal_utils.py
@@ -1,0 +1,51 @@
+# tests/test_internal_utils.py
+"""Tests for the internal shared utilities in ``chardet._utils``."""
+
+from __future__ import annotations
+
+from chardet._utils import (
+    _DECODE_CHUNK_SIZE,
+    count_deleted,
+    dangling_tail_with_ascii_prefix,
+    decodes_completely,
+    decodes_without_error,
+)
+
+
+def test_decodes_without_error_unknown_codec_is_false():
+    assert decodes_without_error(b"hello", "not-a-codec") is False
+
+
+def test_decodes_completely_unknown_codec_is_false():
+    assert decodes_completely(b"hello", "not-a-codec") is False
+
+
+def test_dangling_tail_unknown_codec_is_false():
+    assert dangling_tail_with_ascii_prefix(b"hello", "not-a-codec") is False
+
+
+def test_dangling_tail_invalid_bytes_is_false():
+    """Genuine corruption before the tail is an error, not a deferred tail."""
+    assert dangling_tail_with_ascii_prefix(b"\xff", "utf-8") is False
+
+
+def test_count_deleted_chunked_matches_whole_pass():
+    """Counting through bounded chunks must equal the one-shot count.
+
+    Deletion is per-byte and carries no state across the chunk split, so a
+    window larger than the chunk size counts identically.
+    """
+    data = b"a\x00" * (_DECODE_CHUNK_SIZE // 2 + 17)
+    assert len(data) > _DECODE_CHUNK_SIZE
+    assert count_deleted(data, b"\x00") == data.count(0)
+
+
+def test_decodes_without_error_chunked_sequence_straddles_chunk_edge():
+    """A multi-byte sequence crossing the chunk boundary decodes cleanly.
+
+    The incremental decoder carries its state across chunks, so the split
+    must be invisible even when it lands mid-character.
+    """
+    data = b"a" * (_DECODE_CHUNK_SIZE - 1) + "é".encode() + b"tail"
+    assert len(data) > _DECODE_CHUNK_SIZE
+    assert decodes_without_error(data, "utf-8") is True

--- a/tests/test_language.py
+++ b/tests/test_language.py
@@ -163,3 +163,18 @@ def test_thin_rare_band_is_opt_in_and_score_preserving():
     assert plain_lang in RARE_LANGUAGES
     assert banded_lang not in RARE_LANGUAGES
     assert banded_score == plain_score
+
+
+def test_thin_rare_recheck_keeps_label_when_no_tier_can_score():
+    """A rare label on thin input survives when the scored tiers yield nothing.
+
+    The re-check's only authority is a demotion to a prevalent language;
+    when neither Tier 2 nor Tier 3 produces a verdict (here: an encoding
+    with no model variants that Tier 3 cannot transcode either), the
+    original result must pass through unchanged rather than losing its
+    label.
+    """
+    rare = min(RARE_LANGUAGES)
+    result = DetectionResult("not-a-codec", 0.5, rare, "text/plain")
+    filled = fill_languages(b"ab", [result])
+    assert filled == [result]

--- a/tests/test_markup.py
+++ b/tests/test_markup.py
@@ -4,8 +4,20 @@ from __future__ import annotations
 import re
 from unittest.mock import patch
 
+import pytest
+
+import chardet.pipeline.markup as markup_mod
 from chardet.pipeline import DetectionResult
 from chardet.pipeline.markup import detect_markup_charset, promote_markup_superset
+from chardet.registry import EncodingInfo
+
+#: See the note in tests/test_confusion.py: mypyc resolves a compiled
+#: module's calls to functions imported into it at compile time, so patching
+#: those names only takes effect on interpreted builds.
+_needs_interpreted_build = pytest.mark.skipif(
+    markup_mod.__file__.endswith((".so", ".pyd")),
+    reason="patches a function the compiled module calls natively",
+)
 
 
 def test_promote_markup_superset_passthrough_none_encoding():
@@ -173,3 +185,49 @@ def test_no_promotion_when_reported_codec_decodes_and_structure_ties():
     allowed = frozenset({"cp932", "shift_jis_2004"})
     promoted = promote_markup_superset(data, result, allowed)
     assert promoted.encoding == "shift_jis_2004"
+
+
+def test_ebcdic_meta_charset_declaration():
+    """A charset declaration inside EBCDIC-encoded markup is honoured.
+
+    The head is dominated by high bytes (EBCDIC letters), decodes through
+    cp037 to a ``<meta charset=...>`` tag naming a MAINFRAME-era encoding
+    that decodes the data, so the declaration wins.
+    """
+    html = "<meta charset=cp500><p>hello there dear reader of mainframe pages</p>"
+    data = html.encode("cp500")
+    result = detect_markup_charset(data)
+    assert result is not None
+    assert result.encoding == "cp500"
+    assert result.mime_type == "text/html"
+
+
+def test_ebcdic_declaration_ignored_for_non_mainframe_name():
+    """An EBCDIC-decoded declaration naming a non-MAINFRAME encoding is ignored."""
+    html = "<meta charset=utf-8><p>hello there dear reader of mainframe pages</p>"
+    data = html.encode("cp500")
+    result = detect_markup_charset(data)
+    assert result is None or result.encoding != "utf-8"
+
+
+@_needs_interpreted_build
+def test_promotion_when_superset_structure_scores_higher():
+    """The superset wins when its structural score beats the declared base.
+
+    Both codecs decode the data, so the decision falls to the structural
+    comparison; the scorer is patched to favour the superset, which is the
+    one regime the mutually-decodable inputs in the corpus never reach
+    (a genuine CP932-only byte already fails the shift_jis decode check).
+    """
+    data = "こんにちは、世界。".encode("shift_jis")
+    result = DetectionResult("shift_jis_2004", 0.95, None, "text/html")
+    allowed = frozenset({"cp932", "shift_jis_2004"})
+
+    def fake_score(head: bytes, info: EncodingInfo, ctx: object) -> float:
+        return 2.0 if info.name == "cp932" else 1.0
+
+    with patch.object(markup_mod, "compute_structural_score", fake_score):
+        promoted = promote_markup_superset(data, result, allowed)
+    assert promoted.encoding == "cp932"
+    assert promoted.confidence == result.confidence
+    assert promoted.mime_type == "text/html"

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -665,6 +665,39 @@ def test_rowmax_stale_digest_falls_back_with_warning() -> None:
     models_mod.get_rowmax.cache_clear()
 
 
+def test_rowmax_missing_file_falls_back_with_warning() -> None:
+    """A missing rowmax.bin must fall back to deriving the tables.
+
+    An install stripped of the auxiliary file still works: the tables are
+    derived from the models directly, with a warning so packaging mistakes
+    get noticed.
+    """
+    models_mod.load_models()  # keep the models cache warm past the patch
+
+    def fake_joinpath(name: str) -> MagicMock:
+        ref = MagicMock()
+        ref.read_bytes.side_effect = FileNotFoundError(name)
+        return ref
+
+    models_mod.get_rowmax.cache_clear()
+    try:
+        with (
+            patch.object(
+                models_mod.importlib.resources,
+                "files",
+                return_value=MagicMock(joinpath=MagicMock(side_effect=fake_joinpath)),
+            ),
+            pytest.warns(RuntimeWarning, match="rowmax.bin"),
+        ):
+            derived = models_mod.get_rowmax()
+    finally:
+        models_mod.get_rowmax.cache_clear()
+
+    genuine = models_mod.get_rowmax()
+    assert derived == genuine
+    models_mod.get_rowmax.cache_clear()
+
+
 def test_score_with_profile_accepts_bytearray_and_memoryview() -> None:
     """The historical bytearray/memoryview table types must keep working.
 
@@ -678,3 +711,73 @@ def test_score_with_profile_accepts_bytearray_and_memoryview() -> None:
     expected = models_mod.score_with_profile(profile, bytes(table))
     assert models_mod.score_with_profile(profile, table) == expected
     assert models_mod.score_with_profile(profile, memoryview(bytes(table))) == expected
+
+
+def test_pack_profile_and_dot_packed_agree_with_dense_scoring() -> None:
+    """The packed kernel buffers must reproduce the dense dot product.
+
+    ``_kernel.py`` is the single implementation for both the compiled and
+    interpreted builds, so its arithmetic is checked directly against a
+    hand-computed dot product.
+    """
+    from chardet._kernel import dot_packed, pack_profile  # noqa: PLC0415
+
+    freq = [0] * 65536
+    freq[0x4142] = 3
+    freq[0x4243] = 5
+    idx, vals = pack_profile([0x4142, 0x4243], freq)
+    assert list(idx) == [0x4142, 0x4243]
+    assert list(vals) == [3, 5]
+    model = bytearray(65536)
+    model[0x4142] = 2
+    model[0x4243] = 10
+    assert dot_packed(idx, vals, bytes(model)) == 3 * 2 + 5 * 10
+
+
+def test_dense_profile_scores_identically_through_packed_kernel(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The packed-kernel scoring path must match the dense path exactly.
+
+    The module docstring calls this parity load-bearing: an interpreted run
+    never takes the packed branch on its own, so the flag is forced here to
+    pin the two branches together.  Scores must be bit-identical — same
+    integer dot product, same norms.
+    """
+    data = ("du texte français avec des accents é è ê " * 8).encode("cp1252")
+    model = bytes([1]) * 65536
+    expected = models_mod.score_with_profile(models_mod.BigramProfile(data), model)
+    assert expected > 0.0
+
+    monkeypatch.setattr(models_mod, "_KERNEL_COMPILED", True)
+    packed_profile = models_mod.BigramProfile(data)
+    assert len(packed_profile.idx_arr) > 0
+    assert models_mod.score_with_profile(packed_profile, model) == expected
+
+
+def test_decompress_tables_truncated_streams_raise() -> None:
+    """Every truncation of a two-table stream must raise, at any cut point.
+
+    Scanning all cuts pins down the exhausted-early exits, including the
+    one where ``flush()`` still yields a final mid-copy strand (the cut
+    that lands inside the back-reference crossing the first table's edge)
+    and the stream is only then found short.
+    """
+    blob = zlib.compress(b"A" * 66000)
+    for cut in range(len(blob)):
+        with pytest.raises(ValueError, match="decompressed size"):
+            _format._decompress_tables(blob[:cut], 0, ["a", "b"])
+
+
+def test_decompress_tables_accepts_unterminated_stream() -> None:
+    """A stream with all table bytes but no end marker parses successfully.
+
+    Mirrors whole-blob ``zlib.decompress`` leniency about trailing state:
+    once every table decompressed and a final flush yields nothing extra,
+    the absence of the deflate end marker is not an error.
+    """
+    payload = b"A" * 65536
+    compressor = zlib.compressobj()
+    blob = compressor.compress(payload) + compressor.flush(zlib.Z_SYNC_FLUSH)
+    tables = _format._decompress_tables(blob, 0, ["a"])
+    assert tables == {"a": payload}

--- a/tests/test_postprocess.py
+++ b/tests/test_postprocess.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from unittest.mock import patch
 
 import pytest
 
@@ -13,6 +14,14 @@ from chardet.pipeline.postprocess import (
     forced_encodings,
     postprocess_results,
     scoring_floor,
+)
+
+#: See the note in tests/test_confusion.py: mypyc resolves a compiled
+#: module's calls to functions imported into it at compile time, so patching
+#: those names only takes effect on interpreted builds.
+_needs_interpreted_build = pytest.mark.skipif(
+    postprocess.__file__.endswith((".so", ".pyd")),
+    reason="patches a function the compiled module calls natively",
 )
 
 
@@ -227,3 +236,161 @@ def test_forced_encodings_triggers_combine():
     """Both triggers near the top force both sets."""
     forced = forced_encodings(["cp1254", "koi8-r"])
     assert set(forced) == {"iso8859-1", "iso8859-15", "cp1252", "koi8-t"}
+
+
+def test_era_rank_unknown_encoding_ranks_last():
+    """An encoding missing from the registry can never win a prevalence tie."""
+    assert postprocess._era_rank("not-a-codec") == 1 << 30
+
+
+def test_high_byte_evidence_without_variants_is_absent():
+    """An encoding with no model variants has no high-byte evidence."""
+    assert postprocess._has_high_byte_evidence(b"\xe9ab", "not-a-codec", None) is False
+
+
+def test_prevalent_dead_heat_skips_binary_entries():
+    """A ``None``-encoding entry inside the dead heat is skipped, not ranked.
+
+    The evidence-free ASCII data leaves the mainframe top without high-byte
+    support, so the modern-web rival wins the heat past the binary entry.
+    """
+    results = [
+        DetectionResult("cp500", 0.30, None),
+        DetectionResult(None, 0.30, None),
+        DetectionResult("cp1252", 0.29995, None),
+    ]
+    resolved = postprocess._prefer_prevalent_on_dead_heat(b"hello", results)
+    assert resolved[0].encoding == "cp1252"
+    assert resolved[0].confidence == 0.30
+
+
+def test_superset_dead_heat_promotes_decoding_superset():
+    """cp932 within the epsilon of shift_jis takes the win."""
+    results = [
+        DetectionResult("shift_jis", 0.30, "ja"),
+        DetectionResult("cp932", 0.29995, "ja"),
+    ]
+    resolved = postprocess._promote_superset_on_dead_heat(b"hello world", results)
+    assert resolved[0].encoding == "cp932"
+    assert resolved[0].confidence == 0.30
+
+
+def test_superset_dead_heat_stops_at_the_epsilon():
+    """A superset ranked below the dead-heat band stays where it is."""
+    results = [
+        DetectionResult("shift_jis", 0.30, "ja"),
+        DetectionResult("euc_jp", 0.2999, "ja"),
+        DetectionResult("cp932", 0.10, "ja"),
+    ]
+    resolved = postprocess._promote_superset_on_dead_heat(b"hello world", results)
+    assert resolved == results
+
+
+def test_superset_dead_heat_without_superset_in_band():
+    """No superset inside the band leaves the ranking untouched."""
+    results = [
+        DetectionResult("shift_jis", 0.30, "ja"),
+        DetectionResult("euc_jp", 0.29999, "ja"),
+    ]
+    resolved = postprocess._promote_superset_on_dead_heat(b"hello world", results)
+    assert resolved == results
+
+
+def test_rare_arbitration_stops_past_the_margin():
+    """A rival trailing by more than the margin is real evidence, not a flip."""
+    results = [
+        DetectionResult("iso8859-14", 0.10, "br"),
+        DetectionResult("cp1252", 0.05, "fr"),
+    ]
+    assert postprocess._arbitrate_rare_language(results) == results
+
+
+def test_rare_arbitration_skips_unlabelled_rivals():
+    """A rival with no language cannot arbitrate; the next prevalent one can."""
+    results = [
+        DetectionResult("iso8859-14", 0.10, "br"),
+        DetectionResult("cp1250", 0.099, None),
+        DetectionResult("cp1252", 0.098, "fr"),
+    ]
+    resolved = postprocess._arbitrate_rare_language(results)
+    assert resolved[0].encoding == "cp1252"
+    assert resolved[0].confidence == 0.10
+
+
+def test_rare_arbitration_needs_a_prevalent_rival():
+    """A neighbourhood of rare-language rivals leaves the winner in place."""
+    results = [
+        DetectionResult("iso8859-14", 0.10, "br"),
+        DetectionResult("iso8859-15", 0.099, "cy"),
+    ]
+    assert postprocess._arbitrate_rare_language(results) == results
+
+
+#: Bare-\r line endings, enough of them to clear the classic-Mac gate.
+_CR_ONLY_DATA = b"line one\rline two\rline three\rline four\r"
+
+
+def test_mac_cr_promotion_skips_art_top():
+    """An art-model win is not reviewed by the prose-based Mac promotion."""
+    results = [
+        DetectionResult("cp437", 0.30, postprocess.ART_LANGUAGE),
+        DetectionResult("mac-roman", 0.299, None),
+    ]
+    resolved = postprocess._promote_mac_on_cr_line_endings(_CR_ONLY_DATA, results)
+    assert resolved == results
+
+
+def test_mac_cr_promotion_promotes_banded_mac_candidate():
+    r"""Bare-\r line endings promote the in-band classic-Mac candidate."""
+    results = [
+        DetectionResult("koi8-r", 0.30, "ru"),
+        DetectionResult("mac-roman", 0.299, None),
+    ]
+    resolved = postprocess._promote_mac_on_cr_line_endings(_CR_ONLY_DATA, results)
+    assert resolved[0].encoding == "mac-roman"
+    assert resolved[0].confidence == 0.30
+
+
+def test_mac_cr_promotion_stops_at_the_band():
+    """A Mac candidate below the confidence band is not promoted."""
+    results = [
+        DetectionResult("koi8-r", 0.30, "ru"),
+        DetectionResult("mac-roman", 0.20, None),
+    ]
+    resolved = postprocess._promote_mac_on_cr_line_endings(_CR_ONLY_DATA, results)
+    assert resolved == results
+
+
+@_needs_interpreted_build
+def test_mac_cr_promotion_vetoed_by_byte_evidence():
+    """The platform prior must not overturn distinguishing-byte evidence.
+
+    When the pairwise verdict says the current top beats the best-ranked
+    Mac candidate, the promotion stops entirely instead of falling through
+    to a lower-ranked sibling with no map to be checked against.
+    """
+    results = [
+        DetectionResult("koi8-r", 0.30, "ru"),
+        DetectionResult("mac-cyrillic", 0.299, "ru"),
+        DetectionResult("mac-roman", 0.298, None),
+    ]
+    with patch.object(postprocess, "confusion_pair_winner", return_value="koi8-r"):
+        resolved = postprocess._promote_mac_on_cr_line_endings(_CR_ONLY_DATA, results)
+    assert resolved == results
+
+
+def test_decodes_under_public_names_rejects_undecodable():
+    """A rival that cannot decode the data is no flip target."""
+    assert postprocess._decodes_under_public_names(b"\xff", "ascii") is False
+
+
+def test_decodable_tie_keeps_winner_when_no_rival_decodes():
+    """A dangling-tail winner stays on top when every rival fails to decode."""
+    results = [
+        DetectionResult("euc_kr", 0.30, "ko"),
+        DetectionResult("ascii", 0.29, None),
+    ]
+    resolved = postprocess._prefer_decodable_on_tie(
+        b"hello \xb0", results, input_truncated=False
+    )
+    assert resolved == results

--- a/tests/test_statistical.py
+++ b/tests/test_statistical.py
@@ -8,15 +8,16 @@ import pytest
 from utils import collect_test_files
 
 from chardet.enums import EncodingEra
-from chardet.models import BigramProfile, get_enc_index
+from chardet.models import BigramProfile, _get_model_norms, get_enc_index
 from chardet.pipeline import DetectionResult
 from chardet.pipeline.orchestrator import _STAT_SCORE_MAX_BYTES
 from chardet.pipeline.postprocess import forced_encodings, scoring_floor
 from chardet.pipeline.statistical import (
     _MIN_NONZERO_FOR_PRESCREEN,
+    _split_variants,
     score_candidates,
 )
-from chardet.registry import get_candidates
+from chardet.registry import REGISTRY, get_candidates
 
 
 def test_score_candidates_returns_sorted_results():
@@ -223,3 +224,40 @@ def test_pruning_contract_holds_on_corpus(path: Path):
     pruned = score_candidates(data, candidates)
     full = score_candidates(data, candidates, full_ranking=True)
     _assert_pruning_contract(pruned, full)
+
+
+def test_split_variants_unknown_norm_never_prunes():
+    """A variant whose norm is unknown gets an infinite upper bound.
+
+    An infinite bound means the prescreen can never skip the variant, so an
+    absent norm degrades to a full score instead of a silently wrong prune.
+    """
+    profile = BigramProfile("Bonjour tout le monde, voici du texte.".encode("cp1252"))
+    norms = _get_model_norms()
+    key = next(k for (_lang, _table, k) in get_enc_index()["cp1252"])
+    saved = norms.pop(key)
+    try:
+        _mb, sb_entries = _split_variants((REGISTRY["cp1252"],), profile)
+    finally:
+        norms[key] = saved
+    bounds = {entry[5]: entry[0] for entry in sb_entries}
+    assert bounds[key] == float("inf")
+
+
+def test_split_variants_zero_norm_bounds_at_zero():
+    """A zero-norm model is bounded at 0.0 instead of dividing by zero.
+
+    ``score_with_profile`` returns 0.0 for such a model, so the bound must
+    match rather than raise ``ZeroDivisionError``.
+    """
+    profile = BigramProfile("Bonjour tout le monde, voici du texte.".encode("cp1252"))
+    norms = _get_model_norms()
+    key = next(k for (_lang, _table, k) in get_enc_index()["cp1252"])
+    saved = norms[key]
+    norms[key] = 0.0
+    try:
+        _mb, sb_entries = _split_variants((REGISTRY["cp1252"],), profile)
+    finally:
+        norms[key] = saved
+    bounds = {entry[5]: entry[0] for entry in sb_entries}
+    assert bounds[key] == 0.0


### PR DESCRIPTION
Coverage had slipped to 95.81% — 104 uncovered statements across 12 modules. This brings it back to **100.00%** and raises `fail_under` from 95 to 100 so it can't slip silently again.

Every gap was traced to its actual branch condition and closed with a behavioral test (~660 lines across nine extended test files plus a new `tests/test_internal_utils.py` for `chardet._utils`):

- **binary** — the EBCDIC plausibility checks: padding-only data, whitespace without high bytes, high bytes without word separators, and genuine EBCDIC text shape.
- **escape** — a UTF-7 base64 run outrunning the evidence bound (ADR-0006's skip-don't-judge case).
- **language** — a thin-input rare label surviving when neither scored tier can produce a verdict.
- **statistical** — prescreen upper bounds for unknown (`inf`) and zero model norms, exercised by mutating the shared cached norms mapping (works on both pure and compiled builds, no patching).
- **markup** — charset declarations inside EBCDIC-encoded markup (a cp500 `<meta charset>` page), and the structural-comparison promotion regime that mutually-decodable corpus data never reaches (scorer patched, `_needs_interpreted_build`-marked).
- **evaluation** — `is_exact_match` None handling; the equivalent-chars and length-mismatch paths of `is_equivalent_detection`.
- **models** — the missing-`rowmax.bin` fallback, direct `_kernel` arithmetic, and the packed-kernel scoring branch forced on interpreted runs and pinned **bit-identical** to the dense path (the parity the module docstring calls load-bearing).
- **_format** — truncated-stream exits including the one where `flush()` still yields a final mid-copy strand; the test scans every cut point of the compressed blob so it survives zlib/zlib-ng framing differences. Also sync-flushed streams with no deflate end marker.
- **_utils** — unknown codecs, the chunked large-window count/decode paths, and a multi-byte sequence straddling the 1 MB chunk edge.
- **confusion** — zero-char decodes in the letter-case table (utf-7's `+`), implausible-letter context preferences, per-side demotion accounting, the decisive-vote short-circuit in `confusion_pair_winner`, cross-family corroboration via synthetic 52-diff maps (interpreted-only), the art-language passthrough, and the strict tier's decisive and corroborated king-of-the-hill promotions.
- **postprocess** — era rank for unknown encodings, the dead-heat superset and prevalence promotions, rare-language arbitration bounds, the classic-Mac bare-`\r` promotion including its byte-evidence veto, and the decode-safety flip when no rival decodes.

Two guards are provably unreachable and are excluded with explanatory `pragma: no cover` comments instead of synthetic tests:

- the oversized-flush guard in `_format._decompress_tables` — a flush strand is at most one back-reference (258 bytes) and only ever lands in a fresh 65536-byte table;
- the empty-profile guard in `resolve_by_bigram_rescore` — the hit prefilter already returned, and any hit byte forms at least one bigram once `len(data) >= 2`.

Tests that patch functions called *inside* mypyc-compiled modules use the existing `_needs_interpreted_build` skip marker (coverage is measured on pure builds; compiled builds run the real paths natively).

## Testing

- Full suite: 2,493 passed, coverage **100.00%**, gate at `fail_under = 100`.
- `sphinx-build -W` docs build passes (changelog entry added under Unreleased → Build).
- `ruff check` and `ruff format --check` pass on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Py4AomcaGn2MC9CeHkruFJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Py4AomcaGn2MC9CeHkruFJ)_